### PR TITLE
Add global search bar to navigation and replace taxon overview with genome list overview

### DIFF
--- a/public/js/p3/resources/bv-brc.css
+++ b/public/js/p3/resources/bv-brc.css
@@ -972,7 +972,7 @@ pre.bv-brc-code-block button:active {
   top: 45px;
   right: 0rem;
   left: 0rem;
-  background-color: var(--blue);
+  background-color: var(--maage-primary-400);
   padding: 1rem;
 }
 

--- a/public/js/p3/widget/templates/GlobalSearch.html
+++ b/public/js/p3/widget/templates/GlobalSearch.html
@@ -11,11 +11,7 @@
               <option selected="true" value="everything">All Data Types</option>
               <option value="genomes">Genomes</option>
               <option value="genome_features">Features</option>
-              <option value="proteins">Proteins</option>
-              <option value="sp_genes">Specialty Genes</option>
-              <option value="protein_structures">Protein Structures</option>
-              <option value="pathways">Pathways</option>
-              <option value="subsystems">Subsystems</option>
+              <option value="sp_genes">AMR &amp; Virulence Genes</option>
               <option value="taxonomy">Taxa</option>
             </span>
             <i

--- a/public/js/p3/widget/viewer/Taxonomy.js
+++ b/public/js/p3/widget/viewer/Taxonomy.js
@@ -1,11 +1,11 @@
 define([
   'dojo/_base/declare', 'dojo/_base/Deferred', 'dojo/request', 'dojo/_base/lang', 'dojo/topic',
   './_GenomeList', '../Phylogeny', '../../util/PathJoin', '../../store/SFVTViruses',
-  '../TaxonomyTreeGridContainer', '../TaxonomyOverview', '../../util/QueryToEnglish'
+  '../TaxonomyTreeGridContainer', '../GenomeListOverview', '../../util/QueryToEnglish'
 ], function (
   declare, Deferred, xhr, lang, Topic,
   GenomeList, Phylogeny, PathJoin, SFVTViruses,
-  TaxonomyTreeGrid, TaxonomyOverview, QueryToEnglish
+  TaxonomyTreeGrid, GenomeListOverview, QueryToEnglish
 ) {
   return declare([GenomeList], {
     params: null,
@@ -346,7 +346,7 @@ define([
     },
 
     createOverviewPanel: function () {
-      return new TaxonomyOverview({
+      return new GenomeListOverview({
         title: 'Overview',
         id: this.viewer.id + '_overview'
       });

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,3 +1,9 @@
+<style>
+  #p3header-search,
+  #mobile-search-icon {
+    display: none !important;
+  }
+</style>
 <div id="maage-homepage" class="pb-10 bg-[#f8f9fa]">
 	<div id="bv-brc-home" class="bg-[#f8f9fa]">
 		<div class="maage-home">

--- a/views/javascript.ejs
+++ b/views/javascript.ejs
@@ -1,4 +1,20 @@
 <script>
+  function toggleMenu() {
+    var navbar = document.getElementById("mobile-navbar");
+    if (navbar) {
+      navbar.classList.toggle("hidden");
+    }
+  }
+
+  function toggleSearch() {
+    var searchButton = document.querySelector('.search-icon');
+    var searchbar = document.getElementById("mobile-searchbar");
+    if (searchButton) searchButton.classList.toggle('open');
+    if (searchbar) searchbar.classList.toggle("hidden");
+  }
+</script>
+
+<script>
 dojoConfig = {
     parseOnLoad: false,
     packages: [

--- a/views/navbar.ejs
+++ b/views/navbar.ejs
@@ -251,10 +251,22 @@
           </div>
         </div>
       </div>
+
+      <div id="p3header-search" style="width: 120px;flex-grow: 0.85;margin-right: 10px;">
+        <input style="width:100%;font-size:1em;" class="showOnLoad dijitHidden"
+               data-dojo-type="p3/widget/GlobalSearch"/>
+      </div>
+
       <div id="bv-brc-right-header">
         <div class="HideWithAuth authLinks showOnLoad dijitHidden">
           <a class="navigationLink login-btn" href="/register">Register</a>
           <a class="navigationLink register-btn" href="/login">Login</a>
+        </div>
+
+        <div id="mobile-search-icon">
+          <button class="search-icon" onclick="toggleSearch()">
+            <span class="icon-search fa-2x"></span>
+          </button>
         </div>
         <div class="showOnLoad ShowWithAuth dijitHidden">
           <div class="showOnLoad ShowWithAuth dijitHidden topMenuButtonIcon" data-dojo-type="dijit/form/DropDownButton">
@@ -282,6 +294,12 @@
             <span class="icon-bars fa-2x"></span>
           </button>
         </div>
+      </div>
+    </div>
+
+    <div id="mobile-searchbar" class="hidden">
+      <div id="mobile-search-div">
+        <input style="width:100%;font-size:1em;" data-dojo-type="p3/widget/GlobalSearch"/>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Summary
- Added a global search bar to the navigation header, visible on all pages except the homepage (which already has its own MAAGE-styled search widget)
- Replaced the Taxon overview panel with the enhanced Genome List overview panel for taxonomy views

**Changes**

Global Search Bar in Navigation
- views/navbar.ejs: Added the GlobalSearch Dojo widget inline in the header (desktop) with responsive mobile support via a collapsible search dropdown and search icon toggle
- views/javascript.ejs: Added toggleMenu() and toggleSearch() functions for mobile hamburger and search bar toggling
- views/home.ejs: Hide the navbar search bar on the homepage via CSS (display: none) to avoid duplication with the existing MAAGEGlobalSearch hero widget
- public/js/p3/widget/templates/GlobalSearch.html: Aligned data type filter options with the MAAGE global search (All Data Types, Genomes, Features, AMR & Virulence Genes, Taxa)
- public/js/p3/resources/bv-brc.css: Updated mobile search dropdown background color from var(--blue) to var(--maage-primary-400) to match the navigation bar

Taxon Overview Replacement
- public/js/p3/widget/viewer/Taxonomy.js: Replaced TaxonomyOverview with GenomeListOverview in the taxonomy viewer, using the enhanced genome list overview panel that includes cgMLST and chart links