### PR TITLE
Update actions/checkout to v6 and fix .github ignore

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: dev
 

--- a/.gitignore
+++ b/.gitignore
@@ -149,7 +149,6 @@ node_repl_history
 .vscode/
 *.code-workspace
 .github/copilot-instructions.md
-.github/
 !maage-web.code-workspace
 .idea/
 .zed/


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6 for Node.js 24 support (fixes deprecation warning)
- Remove `.github/` from `.gitignore` so workflow files are tracked

## Test plan
- [ ] Verify release workflow appears in Actions tab
- [ ] Run release workflow to confirm it works with updated checkout action

🤖 Generated with [Claude Code](https://claude.ai/code)