### PR TITLE
Fix private genome downloads by passing auth token as form field

### DIFF
--- a/public/js/p3/widget/AMRPanelGridContainer.js
+++ b/public/js/p3/widget/AMRPanelGridContainer.js
@@ -46,13 +46,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -67,6 +66,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/BiosetResultHeatmapContainer.js
+++ b/public/js/p3/widget/BiosetResultHeatmapContainer.js
@@ -450,7 +450,31 @@ define([
         var rel = e.target.attributes.rel.value;
         var currentQuery = '?in(feature_id,(' + geneIds + '))&sort(+feature_id)';
 
-        window.open(window.App.dataServiceURL + '/genome_feature/' + currentQuery + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken) + '&http_accept=' + rel + '&http_download=true');
+        var baseUrl = window.App.dataServiceURL + '/genome_feature/?http_accept=' + rel + '&http_download=true';
+
+        var form = domConstruct.create('form', {
+          style: 'display: none;',
+          id: 'downloadForm',
+          enctype: 'application/x-www-form-urlencoded',
+          name: 'downloadForm',
+          method: 'post',
+          action: baseUrl
+        }, document.body);
+        domConstruct.create('input', {
+          type: 'hidden',
+          value: encodeURIComponent(currentQuery),
+          name: 'rql'
+        }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', {
+            type: 'hidden',
+            value: window.App.authorizationToken,
+            name: 'http_authorization'
+          }, form);
+        }
+        form.submit();
+
         popup.close(downloadPT);
       });
 

--- a/public/js/p3/widget/CorrelatedGenesGridContainer.js
+++ b/public/js/p3/widget/CorrelatedGenesGridContainer.js
@@ -1,11 +1,11 @@
 define([
-  'dojo/_base/declare', './GridContainer', 'dojo/on',
+  'dojo/_base/declare', './GridContainer', 'dojo/on', 'dojo/dom-construct',
   './CorrelatedGenesGrid', 'dijit/popup', 'dojo/topic',
   'dijit/TooltipDialog', './FacetFilterPanel', './CorrelatedGenesActionBar',
   'dojo/_base/lang'
 
 ], function (
-  declare, GridContainer, on,
+  declare, GridContainer, on, domConstruct,
   CorrelatedGenesGrid, popup, Topic,
   TooltipDialog, FacetFilterPanel, ContainerActionBar,
   lang
@@ -35,7 +35,32 @@ define([
     var currentQuery = self.actionPanel.currentContainerWidget.get('query');
     console.log('selection: ', selection);
     console.log('DownloadQuery: ', dataType, currentQuery);
-    window.open('/api/' + dataType + '/' + currentQuery + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken) + '&http_accept=' + rel + '&http_download');
+
+    var baseUrl = '/api/' + dataType + '/?http_accept=' + rel + '&http_download=true';
+
+    var form = domConstruct.create('form', {
+      style: 'display: none;',
+      id: 'downloadForm',
+      enctype: 'application/x-www-form-urlencoded',
+      name: 'downloadForm',
+      method: 'post',
+      action: baseUrl
+    }, document.body);
+    domConstruct.create('input', {
+      type: 'hidden',
+      value: encodeURIComponent(currentQuery),
+      name: 'rql'
+    }, form);
+    // Add authorization as form field for POST requests
+    if (window.App.authorizationToken) {
+      domConstruct.create('input', {
+        type: 'hidden',
+        value: window.App.authorizationToken,
+        name: 'http_authorization'
+      }, form);
+    }
+    form.submit();
+
     popup.close(downloadTT);
   });
 

--- a/public/js/p3/widget/DownloadTooltipDialog.js
+++ b/public/js/p3/widget/DownloadTooltipDialog.js
@@ -109,10 +109,6 @@ define([
 
         baseUrl = baseUrl + '?&http_download=true&http_accept=' + accept;
 
-        if (window.App.authorizationToken) {
-          baseUrl = baseUrl + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken);
-        }
-
         var form = domConstruct.create('form', {
           style: 'display: none;',
           id: 'downloadForm',
@@ -122,6 +118,10 @@ define([
           action: baseUrl
         }, this.domNode);
         domConstruct.create('input', { type: 'hidden', value: encodeURIComponent(query), name: 'rql' }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', { type: 'hidden', value: window.App.authorizationToken, name: 'http_authorization' }, form);
+        }
         form.submit();
       }
     },

--- a/public/js/p3/widget/EpitopeAssayGridContainer.js
+++ b/public/js/p3/widget/EpitopeAssayGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/EpitopeGridContainer.js
+++ b/public/js/p3/widget/EpitopeGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/ExperimentGridContainer.js
+++ b/public/js/p3/widget/ExperimentGridContainer.js
@@ -62,13 +62,12 @@ define([
 
           const totalRows = grid.totalRows;
           const currentQuery = `in(exp_id,(${_self.eids.join(',')}))`;
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -83,6 +82,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/FeatureGridContainer.js
+++ b/public/js/p3/widget/FeatureGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/GeneExpressionContainer.js
+++ b/public/js/p3/widget/GeneExpressionContainer.js
@@ -250,10 +250,6 @@ define([
         }
         baseUrl = baseUrl + dataType + '/?';
 
-        if (window.App.authorizationToken) {
-          baseUrl = baseUrl + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken);
-        }
-
         baseUrl = baseUrl + '&http_accept=' + rel + '&http_download=true';
         console.log('DownloadQuery: ', query, ' baseUrl:', baseUrl);
 
@@ -267,6 +263,10 @@ define([
           action: baseUrl
         }, _self.domNode);
         domConstruct.create('input', { type: 'hidden', value: encodeURIComponent(query), name: 'rql' }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', { type: 'hidden', value: window.App.authorizationToken, name: 'http_authorization' }, form);
+        }
         form.submit();
 
         popup.close(downloadTT);

--- a/public/js/p3/widget/GeneExpressionGridContainer.js
+++ b/public/js/p3/widget/GeneExpressionGridContainer.js
@@ -115,13 +115,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -136,6 +135,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/GenomeGridContainer.js
+++ b/public/js/p3/widget/GenomeGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/PathwayGridContainer.js
+++ b/public/js/p3/widget/PathwayGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/PathwayMapHeatmapContainerNew.js
+++ b/public/js/p3/widget/PathwayMapHeatmapContainerNew.js
@@ -440,7 +440,31 @@ define([
         var rel = e.target.attributes.rel.value;
         var currentQuery = '?in(feature_id,(' + featureIds + '))&sort(+feature_id)';
 
-        window.open(window.App.dataServiceURL + '/genome_feature/' + currentQuery + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken) + '&http_accept=' + rel + '&http_download=true');
+        var baseUrl = window.App.dataServiceURL + '/genome_feature/?http_accept=' + rel + '&http_download=true';
+
+        var form = domConstruct.create('form', {
+          style: 'display: none;',
+          id: 'downloadForm',
+          enctype: 'application/x-www-form-urlencoded',
+          name: 'downloadForm',
+          method: 'post',
+          action: baseUrl
+        }, document.body);
+        domConstruct.create('input', {
+          type: 'hidden',
+          value: encodeURIComponent(currentQuery),
+          name: 'rql'
+        }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', {
+            type: 'hidden',
+            value: window.App.authorizationToken,
+            name: 'http_authorization'
+          }, form);
+        }
+        form.submit();
+
         popup.close(downloadPT);
       });
 

--- a/public/js/p3/widget/ProteinFamiliesHeatmapContainerNew.js
+++ b/public/js/p3/widget/ProteinFamiliesHeatmapContainerNew.js
@@ -676,7 +676,31 @@ define([
           return f.feature_id;
         }).join(',') + '))&sort(+feature_id)';
 
-        window.open(window.App.dataServiceURL + '/genome_feature/' + currentQuery + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken) + '&http_accept=' + rel + '&http_download=true');
+        var baseUrl = window.App.dataServiceURL + '/genome_feature/?http_accept=' + rel + '&http_download=true';
+
+        var form = domConstruct.create('form', {
+          style: 'display: none;',
+          id: 'downloadForm',
+          enctype: 'application/x-www-form-urlencoded',
+          name: 'downloadForm',
+          method: 'post',
+          action: baseUrl
+        }, document.body);
+        domConstruct.create('input', {
+          type: 'hidden',
+          value: encodeURIComponent(currentQuery),
+          name: 'rql'
+        }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', {
+            type: 'hidden',
+            value: window.App.authorizationToken,
+            name: 'http_authorization'
+          }, form);
+        }
+        form.submit();
+
         popup.close(downloadPT);
       });
 

--- a/public/js/p3/widget/ProteinFeaturesGridContainer.js
+++ b/public/js/p3/widget/ProteinFeaturesGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/ProteinGridContainer.js
+++ b/public/js/p3/widget/ProteinGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/ProteinStructureGridContainer.js
+++ b/public/js/p3/widget/ProteinStructureGridContainer.js
@@ -52,13 +52,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -73,6 +72,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/SFVTGridContainer.js
+++ b/public/js/p3/widget/SFVTGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/SequenceGridContainer.js
+++ b/public/js/p3/widget/SequenceGridContainer.js
@@ -46,13 +46,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -67,6 +66,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/SerologyGridContainer.js
+++ b/public/js/p3/widget/SerologyGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/SpecialtyGeneGridContainer.js
+++ b/public/js/p3/widget/SpecialtyGeneGridContainer.js
@@ -47,13 +47,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -68,6 +67,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/SpecialtyVFGeneGridContainer.js
+++ b/public/js/p3/widget/SpecialtyVFGeneGridContainer.js
@@ -46,13 +46,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -67,6 +66,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/StrainGridContainer.js
+++ b/public/js/p3/widget/StrainGridContainer.js
@@ -53,13 +53,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -74,6 +73,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/StrainGridContainer_Bunyavirales.js
+++ b/public/js/p3/widget/StrainGridContainer_Bunyavirales.js
@@ -53,13 +53,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -74,6 +73,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/StrainGridContainer_Orthomyxoviridae.js
+++ b/public/js/p3/widget/StrainGridContainer_Orthomyxoviridae.js
@@ -53,13 +53,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -74,6 +73,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/SubsystemGridContainer.js
+++ b/public/js/p3/widget/SubsystemGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/SubsystemMapHeatmapContainer.js
+++ b/public/js/p3/widget/SubsystemMapHeatmapContainer.js
@@ -428,7 +428,31 @@ define([
         var rel = e.target.attributes.rel.value;
         var currentQuery = '?in(feature_id,(' + featureIds + '))&sort(+feature_id)';
 
-        window.open(window.App.dataServiceURL + '/genome_feature/' + currentQuery + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken) + '&http_accept=' + rel + '&http_download=true');
+        var baseUrl = window.App.dataServiceURL + '/genome_feature/?http_accept=' + rel + '&http_download=true';
+
+        var form = domConstruct.create('form', {
+          style: 'display: none;',
+          id: 'downloadForm',
+          enctype: 'application/x-www-form-urlencoded',
+          name: 'downloadForm',
+          method: 'post',
+          action: baseUrl
+        }, document.body);
+        domConstruct.create('input', {
+          type: 'hidden',
+          value: encodeURIComponent(currentQuery),
+          name: 'rql'
+        }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', {
+            type: 'hidden',
+            value: window.App.authorizationToken,
+            name: 'http_authorization'
+          }, form);
+        }
+        form.submit();
+
         popup.close(downloadPT);
       });
 

--- a/public/js/p3/widget/SurveillanceGridContainer.js
+++ b/public/js/p3/widget/SurveillanceGridContainer.js
@@ -51,13 +51,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -72,6 +71,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/TaxonGridContainer.js
+++ b/public/js/p3/widget/TaxonGridContainer.js
@@ -49,13 +49,12 @@ define([
           const dataType = _self.dataModel
           const primaryKey = _self.primaryKey
           const currentQuery = _self.grid.get('query')
-          const authToken = (window.App.authorizationToken) ? `&http_authorization=${encodeURIComponent(window.App.authorizationToken)}` : ''
           const query = `${currentQuery}&sort(${primaryKey})&limit(${totalRows})`
 
           on(downloadTT.domNode, 'div:click', function (evt) {
             const typeAccept = evt.target.attributes.rel.value
 
-            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?${authToken}&http_accept=${typeAccept}&http_download=true`
+            const baseUrl = `${PathJoin(window.App.dataServiceURL, dataType)}/?http_accept=${typeAccept}&http_download=true`
 
             const form = domConstruct.create('form', {
               style: 'display: none;',
@@ -70,6 +69,14 @@ define([
               value: encodeURIComponent(query),
               name: 'rql'
             }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
             form.submit();
 
             popup.close(downloadTT);

--- a/public/js/p3/widget/TaxonomyTreeGridContainer.js
+++ b/public/js/p3/widget/TaxonomyTreeGridContainer.js
@@ -1,10 +1,10 @@
 define([
-  'dojo/_base/declare', './GridContainer',
+  'dojo/_base/declare', './GridContainer', 'dojo/dom-construct',
   './TaxonomyTreeGrid', 'dijit/popup',
   'dijit/TooltipDialog', './FacetFilterPanel',
   'dojo/_base/lang', 'dojo/on'
 ], function (
-  declare, GridContainer,
+  declare, GridContainer, domConstruct,
   Grid, popup,
   TooltipDialog, FacetFilterPanel,
   lang, on
@@ -34,7 +34,32 @@ define([
     var currentQuery = self.actionPanel.currentContainerWidget.get('query');
     // console.log("selection: ", selection);
     // console.log("DownloadQuery: ", dataType, currentQuery );
-    window.open('/api/' + dataType + '/' + currentQuery + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken) + '&http_accept=' + rel + '&http_download');
+
+    var baseUrl = '/api/' + dataType + '/?http_accept=' + rel + '&http_download=true';
+
+    var form = domConstruct.create('form', {
+      style: 'display: none;',
+      id: 'downloadForm',
+      enctype: 'application/x-www-form-urlencoded',
+      name: 'downloadForm',
+      method: 'post',
+      action: baseUrl
+    }, document.body);
+    domConstruct.create('input', {
+      type: 'hidden',
+      value: encodeURIComponent(currentQuery),
+      name: 'rql'
+    }, form);
+    // Add authorization as form field for POST requests
+    if (window.App.authorizationToken) {
+      domConstruct.create('input', {
+        type: 'hidden',
+        value: window.App.authorizationToken,
+        name: 'http_authorization'
+      }, form);
+    }
+    form.submit();
+
     popup.close(downloadTT);
   });
 

--- a/public/js/p3/widget/TranscriptomicsGeneHeatmapContainerNew.js
+++ b/public/js/p3/widget/TranscriptomicsGeneHeatmapContainerNew.js
@@ -450,7 +450,31 @@ define([
         var rel = e.target.attributes.rel.value;
         var currentQuery = '?in(feature_id,(' + geneIds + '))&sort(+feature_id)';
 
-        window.open(window.App.dataServiceURL + '/genome_feature/' + currentQuery + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken) + '&http_accept=' + rel + '&http_download=true');
+        var baseUrl = window.App.dataServiceURL + '/genome_feature/?http_accept=' + rel + '&http_download=true';
+
+        var form = domConstruct.create('form', {
+          style: 'display: none;',
+          id: 'downloadForm',
+          enctype: 'application/x-www-form-urlencoded',
+          name: 'downloadForm',
+          method: 'post',
+          action: baseUrl
+        }, document.body);
+        domConstruct.create('input', {
+          type: 'hidden',
+          value: encodeURIComponent(currentQuery),
+          name: 'rql'
+        }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', {
+            type: 'hidden',
+            value: window.App.authorizationToken,
+            name: 'http_authorization'
+          }, form);
+        }
+        form.submit();
+
         popup.close(downloadPT);
       });
 

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -574,7 +574,31 @@ define([
         var dataType = (self.actionPanel.currentContainerWidget.containerType == 'genome_group') ? 'genome' : 'genome_feature';
         var currentQuery = self.actionPanel.currentContainerWidget.get('query');
 
-        window.open(window.App.dataServiceURL + '/' + dataType + '/' + currentQuery + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken) + '&http_accept=' + rel + '&http_download=true');
+        var baseUrl = window.App.dataServiceURL + '/' + dataType + '/?http_accept=' + rel + '&http_download=true';
+
+        var form = domConstruct.create('form', {
+          style: 'display: none;',
+          id: 'downloadForm',
+          enctype: 'application/x-www-form-urlencoded',
+          name: 'downloadForm',
+          method: 'post',
+          action: baseUrl
+        }, document.body);
+        domConstruct.create('input', {
+          type: 'hidden',
+          value: encodeURIComponent(currentQuery),
+          name: 'rql'
+        }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', {
+            type: 'hidden',
+            value: window.App.authorizationToken,
+            name: 'http_authorization'
+          }, form);
+        }
+        form.submit();
+
         popup.close(downloadTT);
       });
 
@@ -609,14 +633,36 @@ define([
         var dataType = type === 'genome_group' ? 'genome' : 'genome_feature';
         var currentQuery = self.getQuery(selection[0]);
 
-        var urlStr = window.App.dataServiceURL + '/' + dataType + '/' + currentQuery + '&http_authorization=' +
-          encodeURIComponent(window.App.authorizationToken) + '&http_accept=' + rel + '&limit(25000)&http_download=true';
-
         // cursorMark requires a sort on an unique key
-        urlStr += type === 'genome_group' ? '&sort(+genome_id)' : '&sort(+feature_id)';
+        var sortField = type === 'genome_group' ? 'genome_id' : 'feature_id';
+        var query = currentQuery + '&limit(25000)&sort(+' + sortField + ')';
 
-        window.open(urlStr);
-        popup.close(downloadTT);
+        var baseUrl = window.App.dataServiceURL + '/' + dataType + '/?http_accept=' + rel + '&http_download=true';
+
+        var form = domConstruct.create('form', {
+          style: 'display: none;',
+          id: 'downloadForm',
+          enctype: 'application/x-www-form-urlencoded',
+          name: 'downloadForm',
+          method: 'post',
+          action: baseUrl
+        }, document.body);
+        domConstruct.create('input', {
+          type: 'hidden',
+          value: encodeURIComponent(query),
+          name: 'rql'
+        }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', {
+            type: 'hidden',
+            value: window.App.authorizationToken,
+            name: 'http_authorization'
+          }, form);
+        }
+        form.submit();
+
+        popup.close(downloadTTSelect);
       });
 
       this.actionPanel.addAction('SelectDownloadTable', 'fa icon-download fa-2x', {

--- a/public/js/p3/widget/actions/TableDownload.js
+++ b/public/js/p3/widget/actions/TableDownload.js
@@ -1,7 +1,7 @@
 define(
-  ['dijit/popup', 'dijit/TooltipDialog', 'dojo/on'],
+  ['dijit/popup', 'dijit/TooltipDialog', 'dojo/on', 'dojo/dom-construct'],
 
-  function (popup, TooltipDialog, on) {
+  function (popup, TooltipDialog, on, domConstruct) {
 
     return function (options) {
 
@@ -34,12 +34,33 @@ define(
             var dataType = options.dataType;
             var currentQuery = options.getQuery();
             console.log('DownloadQuery: ', currentQuery);
-            var url = window.App.dataAPI + dataType + '/?' + currentQuery + '&sort(+' + options.primaryKey + ')&limit(' + options.limit + ')&http_accept=' + rel + '&http_download=true';
-            if (window.App.authorizationToken) {
-              url = url + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken);
-            }
+            var query = currentQuery + '&sort(+' + options.primaryKey + ')&limit(' + options.limit + ')';
 
-            window.open(url);
+            var baseUrl = window.App.dataAPI + dataType + '/?http_accept=' + rel + '&http_download=true';
+
+            var form = domConstruct.create('form', {
+              style: 'display: none;',
+              id: 'downloadForm',
+              enctype: 'application/x-www-form-urlencoded',
+              name: 'downloadForm',
+              method: 'post',
+              action: baseUrl
+            }, document.body);
+            domConstruct.create('input', {
+              type: 'hidden',
+              value: encodeURIComponent(query),
+              name: 'rql'
+            }, form);
+            // Add authorization as form field for POST requests
+            if (window.App.authorizationToken) {
+              domConstruct.create('input', {
+                type: 'hidden',
+                value: window.App.authorizationToken,
+                name: 'http_authorization'
+              }, form);
+            }
+            form.submit();
+
             popup.close(downloadTT);
           });
 

--- a/public/js/p3/widget/viewer/FASTA.js
+++ b/public/js/p3/widget/viewer/FASTA.js
@@ -74,9 +74,6 @@ define([
         var query = this.state.search + '&sort(+' + this.primaryKey + ')&limit(' + this.limit + ')';
         var baseUrl = PathJoin(this.apiServiceUrl, this.dataModel) + '/';
         baseUrl = baseUrl + '?http_download=true&http_accept=application/' + this.type + '+fasta';
-        if (window.App.authorizationToken) {
-          baseUrl = baseUrl + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken);
-        }
         var form = domConstruct.create('form', {
           style: 'display: none;',
           id: 'downloadForm',
@@ -86,6 +83,10 @@ define([
           action: baseUrl
         }, this.domNode);
         domConstruct.create('input', { type: 'hidden', value: encodeURIComponent(query), name: 'rql' }, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', { type: 'hidden', value: window.App.authorizationToken, name: 'http_authorization' }, form);
+        }
         form.submit();
       }));
 

--- a/public/js/p3/widget/viewer/SFVT.js
+++ b/public/js/p3/widget/viewer/SFVT.js
@@ -49,9 +49,6 @@ define([
         const query = 'in(feature_id,(' + featureIds.map(f => f.feature_id).join(',') + '))&sort(+feature_id)&limit(100000)';
 
         baseUrl = baseUrl + '?&http_download=true&http_accept=application/protein+fasta';
-        if (window.App.authorizationToken) {
-          baseUrl = baseUrl + '&http_authorization=' + encodeURIComponent(window.App.authorizationToken);
-        }
 
         let form = domConstruct.create('form', {
           style: 'display: none;',
@@ -62,6 +59,10 @@ define([
           action: baseUrl
         }, dojoQuery('body')[0]);
         domConstruct.create('input', {type: 'hidden', value: encodeURIComponent(query), name: 'rql'}, form);
+        // Add authorization as form field for POST requests
+        if (window.App.authorizationToken) {
+          domConstruct.create('input', {type: 'hidden', value: window.App.authorizationToken, name: 'http_authorization'}, form);
+        }
         form.submit();
       }));
     } else {


### PR DESCRIPTION
## Summary
- Fixes private genome table downloads that stopped working after API security fixes
- Converts all table download functions from using `window.open()` with `http_authorization` in the URL to using form POST with `http_authorization` as a hidden form field
- Updates 35 files across GridContainers, HeatmapContainers, and viewer components

## Background
The API security fixes now whitelist URL parameters and restrict passing auth tokens in URLs. This change ensures authentication tokens are passed securely via form POST fields instead of URL query parameters.

## Files Changed
- **GridContainer files (23)**: AMRPanelGridContainer, EpitopeAssayGridContainer, EpitopeGridContainer, ExperimentGridContainer, FeatureGridContainer, GeneExpressionGridContainer, GenomeGridContainer, PathwayGridContainer, ProteinFeaturesGridContainer, ProteinGridContainer, ProteinStructureGridContainer, SFVTGridContainer, SequenceGridContainer, SerologyGridContainer, SpecialtyGeneGridContainer, SpecialtyVFGeneGridContainer, StrainGridContainer, StrainGridContainer_Bunyavirales, StrainGridContainer_Orthomyxoviridae, SubsystemGridContainer, SurveillanceGridContainer, TaxonGridContainer, TaxonomyTreeGridContainer
- **Heatmap containers (5)**: BiosetResultHeatmapContainer, PathwayMapHeatmapContainerNew, ProteinFamiliesHeatmapContainerNew, SubsystemMapHeatmapContainer, TranscriptomicsGeneHeatmapContainerNew
- **Other containers (4)**: CorrelatedGenesGridContainer, GeneExpressionContainer, WorkspaceBrowser, DownloadTooltipDialog
- **Actions/viewers (3)**: actions/TableDownload, viewer/FASTA, viewer/SFVT

## Test plan
- [ ] Test downloading table data from genome list page with private genomes
- [ ] Test downloading table data from feature list page
- [ ] Test downloading from heatmap views
- [ ] Test downloading from workspace browser (genome groups, feature groups)
- [ ] Verify auth token is not visible in URL/browser history

🤖 Generated with [Claude Code](https://claude.com/claude-code)