### PR TITLE
Fix job result viewer for paths with special characters

### DIFF
--- a/public/js/p3/widget/viewer/JobResult.js
+++ b/public/js/p3/widget/viewer/JobResult.js
@@ -2,12 +2,12 @@ define([
   'dojo/_base/declare', 'dijit/layout/BorderContainer', 'dojo/on',
   'dojo/dom-class', 'dijit/layout/ContentPane', 'dojo/dom-construct',
   '../PageGrid', '../formatter', '../../WorkspaceManager', 'dojo/_base/lang',
-  'dojo/dom-attr', '../WorkspaceExplorerView', 'dijit/Dialog', '../../util/encodePath'
+  'dojo/dom-attr', '../WorkspaceExplorerView', 'dijit/Dialog'
 ], function (
   declare, BorderContainer, on,
   domClass, ContentPane, domConstruct,
   Grid, formatter, WorkspaceManager, lang,
-  domAttr, WorkspaceExplorerView, Dialog, encodePath
+  domAttr, WorkspaceExplorerView, Dialog
 ) {
   return declare([BorderContainer], {
     baseClass: 'ExperimentViewer',
@@ -149,7 +149,7 @@ define([
 
       this.inherited(arguments);
       this.viewHeader = new ContentPane({ content: 'Loading data from ' + this.data.name + ' job file.', region: 'top', style: 'width:90%;height:30%;' });
-      this.viewer = new WorkspaceExplorerView({ region: 'center', path: encodePath(this._hiddenPath) });
+      this.viewer = new WorkspaceExplorerView({ region: 'center', path: this._hiddenPath });
       this.addChild(this.viewHeader);
       this.addChild(this.viewer);
 


### PR DESCRIPTION
## Summary
- Remove incorrect `encodePath()` call when passing path to `WorkspaceExplorerView`
- The path should be decoded when passed to internal API methods, not encoded
- Fixes job data not appearing for workspace paths containing spaces or other special characters

## Problem
Job data was not appearing on workspace pages with special characters in the path (like spaces encoded as `%20`), e.g., `/workspace/user@patricbrc.org/home/Buchnera%20aphidicola%20testx`

## Root Cause
In `JobResult.js`, the path was being incorrectly encoded before being passed to `WorkspaceExplorerView`, which then passes it to `WorkspaceManager.getFolderContents()`. Since `getFolderContents()` expects a decoded path, the lookup for the hidden job folder was failing.

## Test plan
- [ ] Navigate to a job result with spaces in the workspace path
- [ ] Verify job metadata and output files are displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)