### PR TITLE
Fix Feature breadcrumb description overlapping with tabs

### DIFF
--- a/public/js/p3/widget/viewer/Feature.js
+++ b/public/js/p3/widget/viewer/Feature.js
@@ -170,6 +170,7 @@ define([
           this.changeToVirusContext();
         }
 	*/
+        this.resize();
       }));
 
       var content = [];
@@ -186,7 +187,7 @@ define([
         content.push(feature.product);
       }
 
-      this.totalCountNode.innerHTML = '<br/>' + content.map(function (d) {
+      this.totalCountNode.innerHTML = content.map(function (d) {
         return '<span><b>' + d + '</b></span>';
       }).join(' <span class="pipe">|</span> ');
     },

--- a/public/js/p3/widget/viewer/Genome.js
+++ b/public/js/p3/widget/viewer/Genome.js
@@ -401,11 +401,11 @@ define([
       // this.viewer.addChild(this.phylogeny);
       this.viewer.addChild(this.browser);
       // this.viewer.addChild(this.circular);
-      // this.viewer.addChild(this.sequences);
+      this.viewer.addChild(this.sequences);
       this.viewer.addChild(this.features);
       // this.viewer.addChild(this.proteins);
       // this.viewer.addChild(this.structures);
-      // this.viewer.addChild(this.specialtyGenes);
+      this.viewer.addChild(this.specialtyGenes);
       // this.viewer.addChild(this.proteinFeatures);
       // this.viewer.addChild(this.proteinFamilies);
       // this.viewer.addChild(this.pathways);

--- a/public/js/p3/widget/viewer/GenomeList.js
+++ b/public/js/p3/widget/viewer/GenomeList.js
@@ -188,14 +188,14 @@ define([
 
       this.viewer.addChild(this.overview)
       this.viewer.addChild(this.genomes)
-      this.viewer.addChild(this.sequences);
       this.viewer.addChild(this.amr);
+      this.viewer.addChild(this.sequences);
       this.viewer.addChild(this.features);
       // this.viewer.addChild(this.proteins);
       this.viewer.addChild(this.specialtyGenes);
       // this.viewer.addChild(this.proteinFamilies);
-      this.viewer.addChild(this.pathways);
-      this.viewer.addChild(this.subsystems);
+      // this.viewer.addChild(this.pathways);
+      // this.viewer.addChild(this.subsystems);
       // this.viewer.addChild(this.experiments);
     }
   });

--- a/public/js/p3/widget/viewer/Taxonomy.js
+++ b/public/js/p3/widget/viewer/Taxonomy.js
@@ -32,7 +32,7 @@ define([
         state: this.state
       });
       // this.viewer.addChild(this.phylogeny, 1);
-      this.viewer.addChild(this.taxontree, 2);
+      this.viewer.addChild(this.taxontree, 1);
 
       this.watch('taxonomy', lang.hitch(this, 'onSetTaxonomy'));
     },
@@ -62,8 +62,8 @@ define([
       // this.viewer.addChild(this.sequences, 5)
       this.viewer.addChild(this.specialtyGenes, 8);
       // this.viewer.addChild(this.proteinFamilies, 10);
-      this.viewer.addChild(this.pathways, 11);
-      this.viewer.addChild(this.subsystems, 12);
+      // this.viewer.addChild(this.pathways, 11);
+      // this.viewer.addChild(this.subsystems, 12);
       // this.viewer.addChild(this.transcriptomics, 13);
       // this.viewer.addChild(this.interactions, 14);
     },
@@ -74,8 +74,8 @@ define([
       // this.viewer.removeChild(this.sequences);
       this.viewer.removeChild(this.specialtyGenes);
       // this.viewer.removeChild(this.proteinFamilies);
-      this.viewer.removeChild(this.pathways);
-      this.viewer.removeChild(this.subsystems);
+      // this.viewer.removeChild(this.pathways);
+      // this.viewer.removeChild(this.subsystems);
       // this.viewer.removeChild(this.transcriptomics);
       // this.viewer.removeChild(this.interactions);
     },

--- a/public/js/p3/widget/viewer/_GenomeList.js
+++ b/public/js/p3/widget/viewer/_GenomeList.js
@@ -316,8 +316,8 @@ define([
       this.viewer.addChild(this.specialtyGenes);
       // this.viewer.addChild(this.proteinFeatures);
       // this.viewer.addChild(this.epitope);
-      this.viewer.addChild(this.pathways);
-      this.viewer.addChild(this.subsystems);
+      // this.viewer.addChild(this.pathways);
+      // this.viewer.addChild(this.subsystems);
       // this.viewer.addChild(this.experiments);
       // this.viewer.addChild(this.interactions);
       this.viewer.addChild(this.surveillance);

--- a/public/maage/css/src/styles.css
+++ b/public/maage/css/src/styles.css
@@ -1738,7 +1738,8 @@ span#dijit_form_DropDownButton_0 > span.dijitReset.dijitInline.dijitArrowButtonI
 
 .PerspectiveHeader .PerspectiveTotalCount {
   color: var(--maage-secondary-700) !important;
-  white-space: nowrap;
+  flex-basis: 100%;
+  white-space: normal;
 }
 
 div.dijitTabInner.dijitTabContent.dijitTab.dijitTabChecked.dijitChecked {


### PR DESCRIPTION
- Add resize() after async taxonomy content loads in Feature.js
- Make PerspectiveTotalCount use flex-basis:100% to force own line
- Change white-space to normal to allow text wrapping
- Remove redundant <br/> from totalCountNode innerHTML

Also includes:
- Enable Sequences and Specialty Genes tabs in Genome view
- Reorder and disable Pathways/Subsystems tabs in GenomeList
- Disable Pathways/Subsystems in _GenomeList and Taxonomy views
- Fix Taxonomy tree tab position