### PR TITLE
fix: change breadcrumb container from div to span in PerspectiveQuery

### DIFF
--- a/public/js/p3/widget/viewer/TabViewerBase.js
+++ b/public/js/p3/widget/viewer/TabViewerBase.js
@@ -67,12 +67,14 @@ define([
         innerHTML: this.perspectiveLabel
       }, headerContent);
 
-      this.queryNode = domConstruct.create('span', { 'class': 'PerspectiveQuery' }, headerContent);
+      var queryRow = domConstruct.create('div', { 'class': 'PerspectiveQueryRow' }, headerContent);
+
+      this.queryNode = domConstruct.create('span', { 'class': 'PerspectiveQuery' }, queryRow);
 
       this.totalCountNode = domConstruct.create('span', {
         'class': 'PerspectiveTotalCount',
         innerHTML: '( loading... )'
-      }, headerContent);
+      }, queryRow);
 
       this.viewer = new TabContainer({
         region: 'center'

--- a/public/js/p3/widget/viewer/Taxonomy.js
+++ b/public/js/p3/widget/viewer/Taxonomy.js
@@ -358,7 +358,7 @@ define([
       }
 
       // Build breadcrumb using safe DOM construction to prevent XSS
-      var container = domConstruct.create('div');
+      var container = domConstruct.create('span');
 
       visibleIndexes.forEach(function (idx, i) {
         if (i > 0) {

--- a/public/maage/css/src/styles.css
+++ b/public/maage/css/src/styles.css
@@ -1697,22 +1697,39 @@ span#dijit_form_DropDownButton_0 > span.dijitReset.dijitInline.dijitArrowButtonI
 }
 
 .PerspectiveHeader {
-  /* Use flexbox to keep all elements on one line */
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.4em;
+  row-gap: 0;
   align-items: baseline;
-  gap: 0.5em;
+  margin: 0;
+  padding: 0;
+}
+
+.PerspectiveHeader > * {
+  grid-column: 2;
+}
+
+.PerspectiveHeader .PerspectiveQueryRow {
+  grid-column: 2;
+  line-height: 1.4;
 }
 
 .PerspectiveHeader i.fa.PerspectiveIcon {
   color: var(--maage-primary-500) !important;
+  grid-column: 1;
+  grid-row: 1 / 3;
+  align-self: center;
+  float: none !important;
+  margin: 0 !important;
 }
 
 .patric .PerspectiveHeader div.PerspectiveType {
   font-size: 17px !important;
   font-weight: 500 !important;
-  /* Make the label inline within the flex container */
-  display: inline;
+  margin: 0;
+  padding: 0;
+  line-height: 1.3;
 }
 
 .PerspectiveHeader span.queryModel {
@@ -1736,10 +1753,13 @@ span#dijit_form_DropDownButton_0 > span.dijitReset.dijitInline.dijitArrowButtonI
   font-family: 'Inter', sans-serif !important;
 }
 
+.PerspectiveHeader span.PerspectiveQuery {
+  /* inline within QueryRow */
+}
+
 .PerspectiveHeader .PerspectiveTotalCount {
   color: var(--maage-secondary-700) !important;
-  flex-basis: 100%;
-  white-space: normal;
+  white-space: nowrap;
 }
 
 div.dijitTabInner.dijitTabContent.dijitTab.dijitTabChecked.dijitChecked {


### PR DESCRIPTION
- Replace div with span in Taxonomy.js buildHeaderContent() to fix invalid HTML (block element inside inline element)
- Add PerspectiveQueryRow wrapper in TabViewerBase.js to keep query and count on the same line
- Update PerspectiveHeader CSS to use grid layout for proper two-line alignment (icon+label on line 1, breadcrumb+count on line 2)