### PR TITLE
Genome overview: hide protein features, filter specialty genes, fix t…

### DIFF
--- a/public/js/p3/resources/SummaryWidget.css
+++ b/public/js/p3/resources/SummaryWidget.css
@@ -126,12 +126,22 @@
 }
 
 /* Genomic Features at genome overview */
+.patric .gfSummaryWidget.SummaryWidget .chartNode,
+.patric .gfSummaryWidget.SummaryWidget .tableNode {
+    height: auto !important;
+    min-height: 175px;
+}
 .patric .gfSummaryWidget.SummaryWidget .field-feature_type {
     width: 60%;
     text-align: left;
 }
 
 /* specialty genes at genome overview */
+.patric .spgSummaryWidget.SummaryWidget .chartNode,
+.patric .spgSummaryWidget.SummaryWidget .tableNode {
+    height: auto !important;
+    min-height: 175px;
+}
 .patric .spgSummaryWidget.SummaryWidget .field-source_x {
     width: 20%;
 }
@@ -163,7 +173,7 @@
 
 /* special properties summary widget at feature overview */
 .patric .spgSummaryWidget.SummaryWidget {
-    height: 250px;
+    height: auto;
 }
 
 /* feature comments summary widget at feature overview */

--- a/public/js/p3/widget/GenomeFeatureSummary.js
+++ b/public/js/p3/widget/GenomeFeatureSummary.js
@@ -16,6 +16,10 @@ define([
     dataModel: 'genome_feature',
     query: '',
     view: 'table',
+    gridOptions: {
+      className: 'dgrid-autoheight',
+      style: 'border: 0px;'
+    },
     baseQuery: '&limit(1)&in(annotation,(PATRIC,RefSeq))&ne(feature_type,source)&facet((pivot,(annotation,feature_type)),(mincount,0))',
     columns: [{
       label: ' ',

--- a/public/js/p3/widget/GenomeOverview.js
+++ b/public/js/p3/widget/GenomeOverview.js
@@ -24,7 +24,7 @@ define([
     genome: null,
     state: null,
     context: 'bacteria',
-    bacteriSummaryWidgets: ['apSummaryWidget', 'gfSummaryWidget', 'pfSummaryWidget', 'spgSummaryWidget'],
+    bacteriSummaryWidgets: ['apSummaryWidget', 'gfSummaryWidget', 'spgSummaryWidget'],
     virusSummaryWidgets: ['gfSummaryWidget'],
     docsServiceURL: window.App.docsServiceURL,
     tutorialLink: 'quick_references/organisms_genome/overview.html',
@@ -53,11 +53,9 @@ define([
       }
     },
     changeToVirusContext: function () {
-      domClass.add(this.pfSummaryWidget.domNode.parentNode, 'hidden');
       domClass.add(this.spgSummaryWidget.domNode.parentNode, 'hidden');
     },
     changeToBacteriaContext: function () {
-      domClass.remove(this.pfSummaryWidget.domNode.parentNode, 'hidden');
       domClass.remove(this.spgSummaryWidget.domNode.parentNode, 'hidden');
     },
     _setGenomeAttr: function (genome) {

--- a/public/js/p3/widget/SpecialtyGeneSummary.js
+++ b/public/js/p3/widget/SpecialtyGeneSummary.js
@@ -19,7 +19,12 @@ define([
     dataModel: 'sp_gene',
     query: '',
     view: 'table',
-    baseQuery: '&limit(1)&facet((field,property_source),(mincount,1))&json(nl,map)',
+    gridOptions: {
+      className: 'dgrid-autoheight',
+      style: 'border: 0px;'
+    },
+    baseQuery: '&in(property,(%22Antibiotic%20Resistance%22,%22Virulence%20Factor%22))&limit(1)&facet((field,property_source),(mincount,1))&json(nl,map)',
+    allowedCategories: ['Antibiotic Resistance', 'Virulence Factor'],
     columns: [
       { label: ' ', field: 'category' },
       { label: 'Source', field: 'source_x' },
@@ -41,12 +46,17 @@ define([
       var d = res.facet_counts.facet_fields.property_source; // now key-value pair
 
       var data = this._tableData = [];
+      var allowedCategories = this.allowedCategories;
       Object.keys(d).forEach(function (key, idx) {
-        chartLabels.push({ text: key, value: idx + 1 });
         var val = key.split(': ');
         var cat = val[0];
         var source = val[1];
 
+        if (allowedCategories && allowedCategories.indexOf(cat) === -1) {
+          return;
+        }
+
+        chartLabels.push({ text: key, value: chartLabels.length + 1 });
         data.push({
           category: cat, source_x: source, y: d[key], property_source: key
         });

--- a/public/js/p3/widget/templates/GenomeOverview.html
+++ b/public/js/p3/widget/templates/GenomeOverview.html
@@ -20,12 +20,14 @@
       data-dojo-type="p3/widget/GenomeFeatureSummary"></div>
     </div>
 
+    <!-- Protein Features section hidden
     <div class="section">
       <h3 style="margin-bottom:-26px;margin-top:40px" class="close section-title" title="Summary of proteins by their functional attributes and protein family assignments"><span class="wrap">Protein Features</span></h3>
       <div class="pfSummaryWidget" data-dojo-attach-point="pfSummaryWidget"
       data-dojo-type="p3/widget/ProteinFeatureSummary"></div>
       <p class="proteinFeature" style="display:none;text-align:center;margin-top:-15px;margin-bottom:40px;font-family:times;font-size:11pt">Feature Count</p>
     </div>
+    -->
 
     <div class="section">
       <h3 style="margin-bottom:-26px;margin-top:40px" class="close section-title" title="Genes of special interest to infectious disease researchers, such as virulence factors, antimicrobial resistance genes, human homologs, and potential drug targets"><span class="wrap">Specialty Genes</span></h3>


### PR DESCRIPTION
…able heights

- Hide Protein Features section and remove its 9 API queries
- Filter Specialty Genes to show only Antibiotic Resistance and Virulence Factor
- Use dgrid-autoheight for Genomic Features and Specialty Genes tables
- Set CSS height: auto for both panels to eliminate scrollbars