### PR TITLE
Fix DOM XSS via postMessage vulnerability (TIKI-W094-1)

### DIFF
--- a/public/js/p3/app/app.js
+++ b/public/js/p3/app/app.js
@@ -120,6 +120,12 @@ define([
       });
 
       on(window, 'message', function (evt) {
+        // Security: Only accept postMessages from same origin to prevent XSS
+        // via malicious cross-origin messages (TIKI-W094-1)
+        if (evt.origin !== window.location.origin) {
+          return;
+        }
+
         var msg = evt.data;
         // console.log("window.message: ", msg);
         /* istanbul ignore else */
@@ -280,14 +286,13 @@ define([
       });
       /* istanbul ignore next */
       on(window, 'message', function (msg) {
-        // Ignore anything not from this origin or known sources
-        if (
-          !msg ||
-          !msg.data ||
-          msg.origin === "https://syndication.twitter.com" || // legacy
-          typeof msg.data !== 'string' ||
-          !msg.data.trim().startsWith('{') // quick sniff test
-        ) {
+        // Security: Only accept postMessages from same origin (TIKI-W094-1)
+        if (!msg || !msg.data || msg.origin !== window.location.origin) {
+          return;
+        }
+
+        // Additional validation for string JSON messages
+        if (typeof msg.data !== 'string' || !msg.data.trim().startsWith('{')) {
           return;
         }
 
@@ -297,8 +302,7 @@ define([
             Topic.publish(parsed.topic, parsed.payload);
           }
         } catch (err) {
-          // Comment this out or add a debug toggle if you're sick of the noise
-          // console.debug("Ignored window message error: ", err);
+          // Silently ignore parse errors from non-JSON messages
         }
       }, '*');
 


### PR DESCRIPTION
## Summary

- **Security fix** for DOM-based XSS vulnerability (Synack TIKI-W094-1, CVSS 6.1 Medium)
- Add origin validation to both postMessage handlers in app.js
- Replace flawed Twitter blocklist with proper same-origin allowlist

## Vulnerability Details

The application had two `postMessage` event handlers that accepted messages from **any origin**. An attacker could:
1. Host a malicious page that opens/iframes the MAAGE-BRC site
2. Send a `postMessage` with XSS payload targeting the /Notification topic
3. The message flows to Dojo Toaster widget which uses `innerHTML`, causing XSS

## Fix

Both handlers now validate `evt.origin === window.location.origin` before processing messages.

## Test plan

- [ ] Verify application loads and functions normally
- [ ] Verify same-origin postMessage functionality still works (e.g., /remote navigation)
- [ ] Verify cross-origin postMessage is rejected
- [ ] Run the Synack PoC (poc.html) - XSS should no longer trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)
