### PR TITLE
Fix proxy forcing HTTPS for HTTP targets

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,7 +91,7 @@ if (proxyConfig) {
     console.log(prox);
     app.use(prox.local, proxy(prox.site, {
       proxyReqPathResolver: req => req.originalUrl.replace(prox.local, ""),
-      https: true
+      https: prox.site.startsWith('https')
     }));
   }
 }


### PR DESCRIPTION
## Summary
- Derive the `https` option from the proxy site URL instead of hardcoding it to `true`
- Allows HTTP proxy targets (e.g., local API services) to work without SSL errors

## Test plan
- [ ] Verify proxy to HTTP targets (e.g., `http://localhost:13001`) no longer produces SSL errors
- [ ] Verify proxy to HTTPS targets (e.g., `https://alpha.bv-brc.org`) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)