### PR TITLE
Use configured mailing list URL for subscription links

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,7 +91,7 @@ if (proxyConfig) {
     console.log(prox);
     app.use(prox.local, proxy(prox.site, {
       proxyReqPathResolver: req => req.originalUrl.replace(prox.local, ""),
-      https: true
+      https: prox.site.startsWith('https')
     }));
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p3-web",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "scripts": {
     "start": "node ./bin/p3-web",

--- a/public/js/p3/widget/UserProfileForm.js
+++ b/public/js/p3/widget/UserProfileForm.js
@@ -349,6 +349,10 @@ define([
         domClass.add(this.cancelButton.domNode, 'dijitHidden');
       }
 
+      if (this.mailingListSignup && window.App.mailinglistURL) {
+        this.mailingListSignup.innerHTML = 'Click <a href="' + window.App.mailinglistURL + '" target="_blank" class="text-maage-secondary-600 font-medium">HERE</a> to sign up for the MAAGE mailing list.';
+      }
+
       // console.log(window.App.authorizationToken);
       if (window.App.authorizationToken !== null && window.App.authorizationToken !== undefined) {
         this.auth = true;
@@ -362,7 +366,7 @@ define([
           w.destroy()
         })
         domConstruct.destroy(this.setPasswordForm)
-        this.notificationsContainer.innerHTML = 'Click <a href="https://lists.bv-brc.org/mailman/listinfo/all-users" target="_blank">HERE</a> to manage your BV-BRC mailing list subscription.'
+        this.notificationsContainer.innerHTML = 'Click <a href="' + window.App.mailinglistURL + '" target="_blank" class="text-maage-secondary-600 font-medium">HERE</a> to manage your MAAGE mailing list subscription.'
         domClass.add(this.registrationHeading, 'dijitHidden')
 
         if (this.userprofileStored.email_verified){

--- a/public/js/p3/widget/templates/UserProfileForm.html
+++ b/public/js/p3/widget/templates/UserProfileForm.html
@@ -46,7 +46,7 @@
             <tr><td style="width:15%;text-align:right;vertical-align:top;">Interests:</td><td colspan="2"><div rows="5" name="interests" style="height:75px;max-width:99%" data-dojo-type="dijit/form/SimpleTextarea" value=""></div></td></tr>
           </tbody>
       </table>
-      <p class="HideWithAuth">Click <a href="https://lists.bv-brc.org/mailman/listinfo/all-users" target="_blank">HERE</a> to sign up for the BV-BRC mailing list.</p>
+      <p class="HideWithAuth" data-dojo-attach-point="mailingListSignup"></p>
     </div>
     <div class="" data-dojo-attach-point="setPasswordForm" style="max-width:580px; display:block; border: 1px solid gray;margin:4px;margin-top: 28px;margin-bottom:28px; padding:4px;padding-top:8px;">
       <span style="position:relative;top: -17px; border: none; background: #fff;padding: 4px; color: #333;font-weight:600;">Set Password</span>
@@ -123,11 +123,5 @@
       <div class="changePWbutton" data-dojo-attach-event="click: onResetClick" style="margin:auto" data-dojo-attach-point="cPWbutton" type="button" data-dojo-type="dijit/form/Button">Change Password</div>
     </form>
     <div class="pwError" style="color:red; margin-top:20px;display:none"><p>The passwords do not match, please fix</p></div>
-  </div>
-  <div data-dojo-attach-point="brcAds" class="" style="padding:8px;margin:8px;font-size:1em;border:1px solid #333;">
-    <h3>About Bioinformatics Resource Centers</h3>
-    <p style="margin-bottom:8px;">The <a href="https://www.niaid.nih.gov/research/bioinformatics-resource-centers" target="_blank">Bioinformatics Resource Centers</a> (BRCs) for Infectious Diseases program was initiated in 2004 with the main objective of providing public access to computational platforms and analysis tools that enable collecting, archiving, updating, and integrating a variety of genomics and related research data relevant to infectious diseases and pathogens and their interaction with hosts.</p>
-    <p style="margin-bottom:8px;">Visit our partner Bioinformatics Resource Center, VEuPathDB, and <a href="https://veupathdb.org/veupathdb/app/user/login?destination=https://veupathdb.org">login</a> there or <a href="https://veupathdb.org/veupathdb/app/user/registration">register</a>.</p>
-    <p>Sign up for cross-BRC email alerts <a href="https://lists.brcgateway.org/mailman/listinfo/brc-all">here</a>.</p>
   </div>
 </div>

--- a/views/pages/about.ejs
+++ b/views/pages/about.ejs
@@ -407,14 +407,10 @@
 											tools, and events.
 										</p>
 
-										<div class="flex flex-col sm:flex-row gap-3 max-w-md mx-auto">
-											<input type="email" placeholder="Your Email Address"
-												class="flex h-10 w-full rounded-md border border-gray/20 bg-gray/10 px-3 py-2 text-md text-maage-text placeholder:text-maage-text/50 focus:outline-none focus:ring-2 focus:ring-maage-300 focus:ring-offset-2" />
-											<button
-												class="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none bg-maage-secondary-500 hover:bg-maage-secondary-600 text-white h-10 px-4 py-2">
-												Subscribe
-											</button>
-										</div>
+										<a href="<%= request.applicationOptions.mailinglistURL %>" target="_blank" rel="noopener noreferrer"
+											class="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 bg-maage-secondary-500 hover:bg-maage-secondary-600 text-white h-10 px-6 py-2">
+											Subscribe
+										</a>
 									</div>
 								</div>
 							</div>


### PR DESCRIPTION
## Summary
- About page: Replace non-functional email form with Subscribe button linking to configured `mailinglistURL`
- User profile: Use `mailinglistURL` config instead of hardcoded BV-BRC link, update text to "MAAGE mailing list"
- User profile: Style mailing list links to match site theme (`text-maage-secondary-600`)
- Remove "About Bioinformatics Resource Centers" section from registration page

The `mailinglistURL` config key was already wired through `app.js` -> `javascript.ejs` -> `window.App.mailinglistURL` but had no value set. Set it in `p3-web.conf` to point to the Mailman 3 subscription page.

## Test plan
- [ ] Set `mailinglistURL` in `p3-web.conf`
- [ ] Verify About page Subscribe button links to the configured URL
- [ ] Verify user profile page shows "MAAGE mailing list" with correct link (both authenticated and unauthenticated views)
- [ ] Verify BRC ads section is removed from registration page

🤖 Generated with [Claude Code](https://claude.com/claude-code)