### PR TITLE
Add MicrobeTrace integration for molecular epidemiology visualization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -72,3 +72,4 @@
 [submodule "microbetrace-src"]
 	path = microbetrace-src
 	url = https://github.com/BV-BRC-dependencies/MicrobeTrace.git
+	branch = maage-stable


### PR DESCRIPTION
## Summary
- Integrates CDC's MicrobeTrace molecular epidemiology tool into the MAAGE workspace
- Adds a MicrobeTrace action button to the workspace browser for supported file types (FASTA, CSV, TSV, Newick, MicrobeTrace sessions)
- Uses MicrobeTrace's partner handoff system to securely open files in a new tab
- Submodule points to [BV-BRC-dependencies/MicrobeTrace](https://github.com/BV-BRC-dependencies/MicrobeTrace) fork (`maage-stable` branch, Angular 18 compatible with Node v22.4+)
- Partner allowlist configured for maage-brc.org, dev.maage-brc.org, and localhost

## Components
- `public/js/p3/widget/viewer/MicrobeTrace.js` — viewer widget with landing page and handoff logic
- `routes/microbetrace.js` — Express route serving MicrobeTrace static assets
- `WorkspaceBrowser.js` — action button for compatible file types
- `microbetrace-src/` — git submodule (BV-BRC-dependencies/MicrobeTrace fork, `maage-stable` branch)
- `npm run build:microbetrace` — build script (must be run after checkout)

## Deployment note
After checkout, `npm run build:microbetrace` must be run to build the MicrobeTrace Angular app into `public/microbetrace/`. See `MICROBETRACE_INTEGRATION.md` for full details.

## Test plan
- [ ] Clean checkout: `git submodule update --init` then `npm run build:microbetrace`
- [ ] Verify `/microbetrace/` loads the MicrobeTrace app
- [ ] Upload a FASTA file to workspace, select it, click MicrobeTrace action button
- [ ] Verify landing page shows file info and "Open in MicrobeTrace" button works
- [ ] Test with CSV, TSV, and Newick files
- [ ] Verify partner handoff completes and data loads in MicrobeTrace

🤖 Generated with [Claude Code](https://claude.com/claude-code)