### PR TITLE
MicrobeTrace: multi-file handoff, .tre support, genome ID fix

### DIFF
--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1221,31 +1221,36 @@ define([
       // MicrobeTrace viewer action for compatible file types
       this.actionPanel.addAction('ViewMicrobeTrace', 'fa icon-network fa-2x', {
         label: 'MicrobeTrace',
-        multiple: false,
+        multiple: true,
+        allowMultiTypes: true,
+        max: 5,
         validTypes: ['fasta', 'csv', 'tsv', 'nwk', 'newick', 'microbetrace', 'microbetrace_session'],
         tooltip: 'Open in MicrobeTrace molecular epidemiology tool'
       }, function (selection, container) {
-        var obj = selection[0];
-        console.log('[MicrobeTrace] Selection obj:', obj);
-        console.log('[MicrobeTrace] obj.path:', obj.path);
-        console.log('[MicrobeTrace] obj.name:', obj.name);
-        // Build the filepath - path should be the directory, name is the filename
-        // But check if path already ends with the filename
-        var path = obj.path || '';
-        var name = obj.name || '';
-        var filepath;
-        if (path.endsWith(name + '/') || path.endsWith(name)) {
-          // Path already contains the filename
-          filepath = path.replace(/\/$/, ''); // Remove trailing slash if present
-        } else {
-          // Need to append the filename
-          if (!path.endsWith('/')) {
-            path = path + '/';
+        function buildFilepath(obj) {
+          var p = obj.path || '';
+          var n = obj.name || '';
+          if (p.endsWith(n + '/') || p.endsWith(n)) {
+            return p.replace(/\/$/, '');
           }
-          filepath = path + name;
+          if (!p.endsWith('/')) {
+            p = p + '/';
+          }
+          return p + n;
         }
-        console.log('[MicrobeTrace] Navigating to filepath:', filepath);
-        Topic.publish('/navigate', { href: '/view/MicrobeTrace' + encodePath(filepath) });
+
+        var primaryPath = buildFilepath(selection[0]);
+        var href = '/view/MicrobeTrace' + encodePath(primaryPath);
+
+        if (selection.length > 1) {
+          var extras = selection.slice(1).map(function (obj) {
+            return 'extraFile=' + encodeURIComponent(buildFilepath(obj));
+          });
+          href += '?' + extras.join('&');
+        }
+
+        console.log('[MicrobeTrace] Navigating to href:', href);
+        Topic.publish('/navigate', { href: href });
       }, false);
 
       this.browserHeader.addAction('ViewNwkXml', 'fa icon-eye fa-2x', {

--- a/public/js/p3/widget/viewer/MicrobeTrace.js
+++ b/public/js/p3/widget/viewer/MicrobeTrace.js
@@ -5,6 +5,7 @@
  * MicrobeTrace molecular epidemiology visualization tool. Files are opened in
  * a new browser tab using MicrobeTrace's partner handoff system.
  *
+ * Supports single or multiple files (e.g., tree + metadata CSV).
  * Supported file types: FASTA, CSV, TSV, Newick trees, and MicrobeTrace sessions.
  *
  * @see https://github.com/CDCgov/MicrobeTrace
@@ -49,6 +50,10 @@ define([
     ],
 
     // Internal state
+    _workspacePaths: null,
+    _workspaceDir: null,
+    _files: null,
+    // Backward-compat single-file properties
     _workspacePath: null,
     _fileContent: null,
     _filename: null,
@@ -63,20 +68,15 @@ define([
 
       console.log('[MicrobeTrace] _setStateAttr received state:', JSON.stringify(state));
 
-      // Extract workspace path from state.pathname
-      // pathname is like /view/MicrobeTrace/user@domain/path/to/file.nwk
+      // Extract primary workspace path from state.pathname
       var path = state.pathname;
       if (path) {
-        // Remove /view/MicrobeTrace prefix to get the workspace path
-        // Handle both /view/MicrobeTrace and /MicrobeTrace prefixes
         path = path.replace(/^\/view\/MicrobeTrace/, '').replace(/^\/MicrobeTrace/, '');
-        // Ensure path starts with /
         if (path && !path.startsWith('/')) {
           path = '/' + path;
         }
       }
 
-      // Also check state.path and state.value as fallbacks
       if (!path) {
         path = state.path || state.value;
       }
@@ -86,24 +86,49 @@ define([
         return;
       }
 
-      console.log('[MicrobeTrace] Extracted path:', path);
-
-      // URL decode the path to handle encoded characters
       try {
         path = decodeURIComponent(path);
-        console.log('[MicrobeTrace] Decoded path:', path);
       } catch (e) {
         console.warn('[MicrobeTrace] Could not decode path:', e);
       }
 
-      console.log('[MicrobeTrace] Loading file from path:', path);
-      this._workspacePath = path;
+      var allPaths = [path];
 
-      // Defer loading until startup completes
-      if (this._started) {
-        this._loadFileInfo(path);
+      // Parse additional files from query string (extraFile= params)
+      var search = state.search;
+      if (search) {
+        if (search.charAt(0) === '?') {
+          search = search.substring(1);
+        }
+        var params = search.split('&');
+        for (var i = 0; i < params.length; i++) {
+          var eqIdx = params[i].indexOf('=');
+          if (eqIdx > -1) {
+            var key = params[i].substring(0, eqIdx);
+            var val = params[i].substring(eqIdx + 1);
+            if (key === 'extraFile' && val) {
+              try {
+                allPaths.push(decodeURIComponent(val));
+              } catch (e) {
+                console.warn('[MicrobeTrace] Could not decode extraFile:', e);
+              }
+            }
+          }
+        }
       }
-      // If not started yet, startup() will call _loadFileInfo
+
+      console.log('[MicrobeTrace] Loading files from paths:', allPaths);
+      this._workspacePaths = allPaths;
+      this._workspacePath = allPaths[0];
+
+      // Compute workspace directory for post-handoff navigation
+      var parts = allPaths[0].split('/');
+      parts.pop();
+      this._workspaceDir = parts.join('/');
+
+      if (this._started) {
+        this._loadFilesInfo(allPaths);
+      }
     },
 
     /**
@@ -113,7 +138,6 @@ define([
       this._set('data', data);
       if (!data) return;
 
-      // Extract path from workspace object metadata
       var meta = data.metadata || data;
       var path = meta.path;
       if (meta.name && path) {
@@ -121,12 +145,14 @@ define([
       }
 
       if (path) {
+        this._workspacePaths = [path];
         this._workspacePath = path;
-        // Defer loading until startup completes
+        var parts = path.split('/');
+        parts.pop();
+        this._workspaceDir = parts.join('/');
         if (this._started) {
-          this._loadFileInfo(path);
+          this._loadFilesInfo([path]);
         }
-        // If not started yet, startup() will call _loadFileInfo
       }
     },
 
@@ -135,9 +161,8 @@ define([
       this.inherited(arguments);
       this._setupUI();
 
-      // If state was set before startup, load now
-      if (this._workspacePath) {
-        this._loadFileInfo(this._workspacePath);
+      if (this._workspacePaths) {
+        this._loadFilesInfo(this._workspacePaths);
       }
     },
 
@@ -145,7 +170,6 @@ define([
      * _setupUI - Create the main content pane
      */
     _setupUI: function () {
-      // Main content pane for the landing page
       this.contentPane = new ContentPane({
         region: 'center',
         style: 'padding: 0; overflow: auto; background: #f8f9fa;'
@@ -154,67 +178,60 @@ define([
     },
 
     /**
-     * _loadFileInfo - Load file info and show landing page
+     * _loadFilesInfo - Load one or more files and show landing page
      */
-    _loadFileInfo: function (workspacePath) {
+    _loadFilesInfo: function (paths) {
       var _self = this;
-
-      // Show loading indicator
       this._showLoading();
 
-      var filename = workspacePath.split('/').pop();
-      var ext = this._getFileExtension(filename);
+      console.log('[MicrobeTrace] Loading files via WorkspaceManager.getObjects:', paths);
 
-      console.log('[MicrobeTrace] Loading file via WorkspaceManager.getObject:', workspacePath);
+      WorkspaceManager.getObjects(paths, false).then(function (results) {
+        _self._files = results.map(function (result) {
+          var fileContent = result.data;
+          if (typeof fileContent === 'object' && fileContent !== null) {
+            fileContent = JSON.stringify(fileContent);
+          }
+          if (!fileContent || typeof fileContent !== 'string') {
+            throw new Error('No file content returned for ' + (result.metadata ? result.metadata.name : 'unknown'));
+          }
+          var filename = result.metadata.name;
+          var ext = _self._getFileExtension(filename);
+          var kind = _self._inferFileKind(ext, fileContent, filename);
+          return {
+            filename: filename,
+            fileType: ext,
+            kind: kind,
+            content: fileContent
+          };
+        });
 
-      // Use WorkspaceManager.getObject to properly handle authentication and shock links
-      WorkspaceManager.getObject(workspacePath, false).then(function (result) {
-        console.log('[MicrobeTrace] Got object result:', result);
-
-        var fileContent = result.data;
-
-        // Handle if data is an object (JSON) - stringify it
-        if (typeof fileContent === 'object' && fileContent !== null) {
-          fileContent = JSON.stringify(fileContent);
+        // Backward compat: set single-file properties from first file
+        if (_self._files.length > 0) {
+          _self._filename = _self._files[0].filename;
+          _self._fileType = _self._files[0].fileType;
+          _self._fileContent = _self._files[0].content;
         }
 
-        if (!fileContent || typeof fileContent !== 'string') {
-          throw new Error('No file content returned');
-        }
-
-        console.log('[MicrobeTrace] File content loaded, size:', fileContent.length);
-        console.log('[MicrobeTrace] File content first 100 chars:', fileContent.substring(0, 100));
-
-        // Store file info for later use
-        _self._filename = filename;
-        _self._fileType = ext;
-        _self._fileContent = fileContent;
-
-        // Determine the file kind for MicrobeTrace
-        var kind = _self._inferFileKind(ext, fileContent, filename);
-
-        // Show the landing page
-        _self._showLandingPage(filename, ext, kind, fileContent.length);
+        _self._showLandingPage();
       }).catch(function (err) {
-        console.error('[MicrobeTrace] Failed to load file:', err);
-        _self._showError('Failed to load file: ' + (err.message || err));
+        console.error('[MicrobeTrace] Failed to load files:', err);
+        _self._showError('Failed to load files: ' + (err.message || err));
       });
     },
 
     /**
      * _showLandingPage - Display landing page with file info and Open button
      */
-    _showLandingPage: function (filename, fileType, kind, fileSize) {
+    _showLandingPage: function () {
       var _self = this;
       domConstruct.empty(this.contentPane.domNode);
 
-      // Create centered landing page container
       var container = domConstruct.create('div', {
         style: 'display: flex; flex-direction: column; align-items: center; justify-content: center; ' +
                'min-height: 100%; padding: 40px; box-sizing: border-box;'
       }, this.contentPane.domNode);
 
-      // MicrobeTrace logo/icon card
       var card = domConstruct.create('div', {
         style: 'background: white; border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.1); ' +
                'padding: 40px 60px; text-align: center; max-width: 500px; width: 100%;'
@@ -226,40 +243,50 @@ define([
         style: 'margin-bottom: 20px;'
       }, card);
 
-      // Title
       domConstruct.create('h2', {
-        innerHTML: 'MicrobeTrace',
+        textContent: 'MicrobeTrace',
         style: 'margin: 0 0 8px 0; font-size: 28px; color: #212529; font-weight: 600;'
       }, card);
 
-      // Subtitle
       domConstruct.create('p', {
-        innerHTML: 'Molecular Epidemiology Visualization Tool',
+        textContent: 'Molecular Epidemiology Visualization Tool',
         style: 'margin: 0 0 30px 0; color: #6c757d; font-size: 14px;'
       }, card);
 
-      // File info section
-      var fileInfo = domConstruct.create('div', {
-        style: 'background: #f8f9fa; border-radius: 8px; padding: 20px; margin-bottom: 30px; text-align: left;'
-      }, card);
+      // File info section for each file
+      var files = this._files || [];
+      for (var i = 0; i < files.length; i++) {
+        var f = files[i];
+        var fileInfo = domConstruct.create('div', {
+          style: 'background: #f8f9fa; border-radius: 8px; padding: 20px; margin-bottom: 15px; text-align: left;'
+        }, card);
 
-      // File icon and name
-      var iconClass = this._getIconForFileType(fileType);
-      domConstruct.create('div', {
-        innerHTML: '<i class="' + iconClass + '" style="margin-right: 10px; color: #495057;"></i>' +
-                   '<strong>' + this._escapeHtml(filename) + '</strong>',
-        style: 'font-size: 16px; margin-bottom: 12px; color: #212529;'
-      }, fileInfo);
+        var iconClass = this._getIconForFileType(f.fileType);
+        var nameDiv = domConstruct.create('div', {
+          style: 'font-size: 16px; margin-bottom: 12px; color: #212529;'
+        }, fileInfo);
+        domConstruct.create('i', {
+          className: iconClass,
+          style: 'margin-right: 10px; color: #495057;'
+        }, nameDiv);
+        var nameStrong = domConstruct.create('strong', {}, nameDiv);
+        nameStrong.textContent = f.filename;
 
-      // File details
-      var details = [];
-      details.push('<strong>Type:</strong> ' + this._getFileTypeLabel(kind));
-      details.push('<strong>Size:</strong> ' + this._formatFileSize(fileSize));
+        var detailsDiv = domConstruct.create('div', {
+          style: 'font-size: 13px; color: #6c757d; line-height: 1.6;'
+        }, fileInfo);
+        var typeSpan = domConstruct.create('div', {}, detailsDiv);
+        domConstruct.create('strong', { textContent: 'Type: ' }, typeSpan);
+        typeSpan.appendChild(document.createTextNode(this._getFileTypeLabel(f.kind)));
+        var sizeSpan = domConstruct.create('div', {}, detailsDiv);
+        domConstruct.create('strong', { textContent: 'Size: ' }, sizeSpan);
+        sizeSpan.appendChild(document.createTextNode(this._formatFileSize(f.content.length)));
+      }
 
-      domConstruct.create('div', {
-        innerHTML: details.join('<br>'),
-        style: 'font-size: 13px; color: #6c757d; line-height: 1.6;'
-      }, fileInfo);
+      // Spacing before button if multiple files
+      if (files.length > 1) {
+        domConstruct.create('div', { style: 'margin-bottom: 15px;' }, card);
+      }
 
       // Open in MicrobeTrace button
       var openBtn = domConstruct.create('button', {
@@ -274,23 +301,24 @@ define([
       on(openBtn, 'mouseleave', function () { this.style.background = '#17a2b8'; });
 
       // Help text
+      var fileCount = files.length > 1 ? files.length + ' files' : 'your file';
       domConstruct.create('p', {
-        innerHTML: 'MicrobeTrace will open in a new browser tab with your file loaded.',
+        textContent: 'MicrobeTrace will open in a new browser tab with ' + fileCount + ' loaded.',
         style: 'margin: 20px 0 0 0; color: #6c757d; font-size: 12px;'
       }, card);
 
-      // Info about MicrobeTrace
+      // About section
       var infoSection = domConstruct.create('div', {
         style: 'margin-top: 30px; text-align: left; max-width: 500px; width: 100%;'
       }, container);
 
       domConstruct.create('h4', {
-        innerHTML: 'About MicrobeTrace',
+        textContent: 'About MicrobeTrace',
         style: 'margin: 0 0 10px 0; font-size: 14px; color: #495057; font-weight: 600;'
       }, infoSection);
 
       domConstruct.create('p', {
-        innerHTML: 'MicrobeTrace is an open-source tool developed by the CDC for visualizing and analyzing ' +
+        textContent: 'MicrobeTrace is an open-source tool developed by the CDC for visualizing and analyzing ' +
                    'molecular epidemiology data. It supports network visualization, phylogenetic trees, ' +
                    'geographic mapping, and more.',
         style: 'margin: 0; color: #6c757d; font-size: 13px; line-height: 1.6;'
@@ -298,15 +326,13 @@ define([
     },
 
     /**
-     * _openInMicrobeTrace - Open MicrobeTrace in a new tab with the file data
-     *
-     * Uses MicrobeTrace's partner handoff receiver page, which properly handles
-     * storing data via localforage before redirecting to the main app.
+     * _openInMicrobeTrace - Open MicrobeTrace in a new tab with file data
      */
     _openInMicrobeTrace: function () {
       var _self = this;
+      var files = this._files || [];
 
-      if (!this._fileContent) {
+      if (!files.length) {
         Topic.publish('/Notification', {
           message: 'File content not loaded. Please try again.',
           type: 'error'
@@ -314,39 +340,34 @@ define([
         return;
       }
 
-      // Trim the file content and check what we have
-      var fileContent = this._fileContent.trim();
-      console.log('[MicrobeTrace] File content first 200 chars:', JSON.stringify(fileContent.substring(0, 200)));
-      console.log('[MicrobeTrace] File content starts with:', fileContent.charAt(0));
+      // Build files array for the payload
+      var filesPayload = files.map(function (f) {
+        return {
+          name: f.filename,
+          kind: f.kind,
+          contents: f.content.trim()
+        };
+      });
 
-      // Determine the file kind for MicrobeTrace
-      var kind = this._inferFileKind(this._fileType, fileContent, this._filename);
-      console.log('[MicrobeTrace] Inferred kind:', kind);
+      var datasetName = files.map(function (f) { return f.filename; }).join(' + ');
 
-      // Generate unique identifiers for the handoff
       var partnerId = 'maage';
       var nonce = 'maage-' + Date.now() + '-' + Math.random().toString(16).slice(2);
 
-      // Create the handoff payload matching MicrobeTrace's expected format
       var payload = {
         type: 'MT_HANDOFF_TRANSFER',
         version: 1,
         partnerId: partnerId,
         nonce: nonce,
         metadata: {
-          datasetName: this._filename,
+          datasetName: datasetName,
           sourceApp: 'MAAGE'
         },
-        files: [{
-          name: this._filename,
-          kind: kind,
-          contents: fileContent
-        }]
+        files: filesPayload
       };
 
-      console.log('[MicrobeTrace] Opening receiver with partnerId:', partnerId, 'nonce:', nonce);
+      console.log('[MicrobeTrace] Opening receiver with partnerId:', partnerId, 'nonce:', nonce, 'files:', filesPayload.length);
 
-      // Open the receiver.html page which will handle the handoff
       var receiverUrl = '/microbetrace/assets/embed/receiver.html?partnerId=' +
                         encodeURIComponent(partnerId) + '&nonce=' + encodeURIComponent(nonce);
 
@@ -361,22 +382,15 @@ define([
       }
 
       // Listen for the READY message from the receiver
-      var messageHandler = function(event) {
-        console.log('[MicrobeTrace] Received message:', event.data);
-
+      var messageHandler = function (event) {
         if (!event.data || event.data.type !== 'MT_HANDOFF_READY') {
           return;
         }
-
-        // Verify it's from our receiver
         if (event.data.partnerId !== partnerId || event.data.nonce !== nonce) {
-          console.log('[MicrobeTrace] Ignoring message with different partnerId/nonce');
           return;
         }
 
         console.log('[MicrobeTrace] Receiver is ready, sending payload');
-
-        // Send the payload to the receiver
         try {
           receiverWindow.postMessage(payload, '*');
           console.log('[MicrobeTrace] Payload sent');
@@ -385,216 +399,50 @@ define([
         }
       };
 
-      // Set up message listener
       window.addEventListener('message', messageHandler);
-
-      // Clean up after 60 seconds
-      setTimeout(function() {
+      setTimeout(function () {
         window.removeEventListener('message', messageHandler);
       }, 60000);
 
-      // Also listen for the stored confirmation
-      var storedHandler = function(event) {
+      // Listen for stored confirmation and navigate back to workspace
+      var storedHandler = function (event) {
         if (!event.data || event.data.type !== 'MT_HANDOFF_TRANSFER' || event.data.status !== 'stored') {
           return;
         }
-
         if (event.data.partnerId !== partnerId || event.data.nonce !== nonce) {
           return;
         }
 
         console.log('[MicrobeTrace] Handoff stored successfully with ID:', event.data.handoffId);
         window.removeEventListener('message', storedHandler);
+        window.removeEventListener('message', messageHandler);
 
         Topic.publish('/Notification', {
-          message: 'MicrobeTrace loaded with ' + _self._filename,
+          message: 'MicrobeTrace loaded with ' + datasetName,
           type: 'success'
         });
+
+        // Navigate back to the workspace directory
+        if (_self._workspaceDir) {
+          Topic.publish('/navigate', { href: '/workspace' + encodePath(_self._workspaceDir) });
+        }
       };
 
       window.addEventListener('message', storedHandler);
-
-      // Clean up stored handler after 60 seconds
-      setTimeout(function() {
+      setTimeout(function () {
         window.removeEventListener('message', storedHandler);
       }, 60000);
 
       Topic.publish('/Notification', {
-        message: 'Opening MicrobeTrace with ' + this._filename,
+        message: 'Opening MicrobeTrace with ' + datasetName,
         type: 'info'
       });
-    },
-
-    /**
-     * _storeInLocalForage - Store data in IndexedDB using localforage's structure
-     *
-     * localforage defaults: database='localforage', store='keyvaluepairs'
-     */
-    _storeInLocalForage: function (key, value) {
-      return new Promise(function (resolve, reject) {
-        // First check if localforage database exists and get its version
-        if (indexedDB.databases) {
-          indexedDB.databases().then(function(databases) {
-            console.log('[MicrobeTrace] Existing databases:', databases);
-            var lfDb = databases.find(function(db) { return db.name === 'localforage'; });
-            if (lfDb) {
-              console.log('[MicrobeTrace] localforage database exists with version:', lfDb.version);
-              openWithVersion(lfDb.version);
-            } else {
-              console.log('[MicrobeTrace] localforage database does not exist, creating new');
-              openWithVersion(undefined);
-            }
-          }).catch(function() {
-            // databases() not supported, try opening without version
-            openWithVersion(undefined);
-          });
-        } else {
-          openWithVersion(undefined);
-        }
-
-        function openWithVersion(version) {
-          var request;
-          if (version !== undefined) {
-            request = indexedDB.open('localforage', version);
-          } else {
-            request = indexedDB.open('localforage');
-          }
-
-          request.onerror = function (event) {
-            console.error('[MicrobeTrace] IndexedDB open error:', event.target.error);
-            reject(new Error('Could not open IndexedDB: ' + event.target.error));
-          };
-
-          request.onupgradeneeded = function (event) {
-            console.log('[MicrobeTrace] Creating localforage database structure');
-            var db = event.target.result;
-            if (!db.objectStoreNames.contains('keyvaluepairs')) {
-              db.createObjectStore('keyvaluepairs');
-            }
-          };
-
-          request.onsuccess = function (event) {
-            var db = event.target.result;
-            console.log('[MicrobeTrace] IndexedDB opened, version:', db.version, 'stores:', Array.from(db.objectStoreNames));
-
-            // Check if keyvaluepairs store exists
-            if (!db.objectStoreNames.contains('keyvaluepairs')) {
-              console.error('[MicrobeTrace] keyvaluepairs store does not exist!');
-              db.close();
-              reject(new Error('keyvaluepairs store not found'));
-              return;
-            }
-
-            try {
-              var transaction = db.transaction(['keyvaluepairs'], 'readwrite');
-              var store = transaction.objectStore('keyvaluepairs');
-
-              console.log('[MicrobeTrace] Putting data with key:', key);
-              var putRequest = store.put(value, key);
-
-              putRequest.onerror = function (event) {
-                console.error('[MicrobeTrace] IndexedDB put error:', event.target.error);
-                db.close();
-                reject(new Error('Failed to store data: ' + event.target.error));
-              };
-
-              putRequest.onsuccess = function () {
-                console.log('[MicrobeTrace] Put succeeded');
-              };
-
-              transaction.oncomplete = function () {
-                console.log('[MicrobeTrace] Transaction complete, verifying...');
-
-                // Verify the data was stored
-                var verifyTx = db.transaction(['keyvaluepairs'], 'readonly');
-                var verifyStore = verifyTx.objectStore('keyvaluepairs');
-                var getRequest = verifyStore.get(key);
-
-                getRequest.onsuccess = function() {
-                  if (getRequest.result) {
-                    console.log('[MicrobeTrace] Verification SUCCESS - data exists');
-                  } else {
-                    console.error('[MicrobeTrace] Verification FAILED - data not found!');
-                  }
-                };
-
-                verifyTx.oncomplete = function() {
-                  db.close();
-                  resolve();
-                };
-              };
-
-              transaction.onerror = function (event) {
-                console.error('[MicrobeTrace] IndexedDB transaction error:', event.target.error);
-                db.close();
-                reject(new Error('Transaction failed: ' + event.target.error));
-              };
-            } catch (e) {
-              console.error('[MicrobeTrace] IndexedDB operation error:', e);
-              db.close();
-              reject(e);
-            }
-          };
-        }
-      });
-    },
-
-    /**
-     * _cleanupOldHandoffs - Remove old handoff data from IndexedDB
-     *
-     * Cleans up expired handoffs (those older than 15 minutes)
-     */
-    _cleanupOldHandoffs: function () {
-      var now = Date.now();
-
-      var request = indexedDB.open('localforage');
-      request.onsuccess = function (event) {
-        var db = event.target.result;
-
-        try {
-          var transaction = db.transaction(['keyvaluepairs'], 'readwrite');
-          var store = transaction.objectStore('keyvaluepairs');
-
-          // Get all keys
-          var keysRequest = store.getAllKeys();
-          keysRequest.onsuccess = function () {
-            var keys = keysRequest.result || [];
-            var handoffKeys = keys.filter(function (key) {
-              return typeof key === 'string' && key.startsWith('handoff:');
-            });
-
-            // Check each handoff key for expiration
-            handoffKeys.forEach(function (key) {
-              var getRequest = store.get(key);
-              getRequest.onsuccess = function () {
-                var data = getRequest.result;
-                if (data && data.expiresAt && data.expiresAt < now) {
-                  store.delete(key);
-                  console.log('[MicrobeTrace] Cleaned up expired handoff:', key);
-                }
-              };
-            });
-          };
-
-          transaction.oncomplete = function () {
-            db.close();
-          };
-        } catch (e) {
-          console.warn('[MicrobeTrace] Could not clean up old handoffs:', e);
-          db.close();
-        }
-      };
-
-      request.onerror = function () {
-        console.warn('[MicrobeTrace] Could not open IndexedDB for cleanup');
-      };
     },
 
     /**
      * _inferFileKind - Determine the MicrobeTrace file kind from extension and content
      */
     _inferFileKind: function (ext, content, filename) {
-      // Check extension first
       if (['fasta', 'fa', 'fna', 'faa', 'fas'].indexOf(ext) >= 0) {
         return 'fasta';
       }
@@ -602,20 +450,14 @@ define([
         return 'newick';
       }
 
-      // Check content patterns
       var trimmed = content.trim();
 
-      // FASTA starts with >
       if (trimmed.charAt(0) === '>') {
         return 'fasta';
       }
-
-      // Newick starts with ( and ends with ;
       if (trimmed.charAt(0) === '(' && trimmed.charAt(trimmed.length - 1) === ';') {
         return 'newick';
       }
-
-      // JSON check for Auspice
       if (trimmed.charAt(0) === '{') {
         try {
           var parsed = JSON.parse(trimmed);
@@ -627,7 +469,6 @@ define([
         }
       }
 
-      // Check filename hints for node/link/matrix
       var lowerName = filename.toLowerCase();
       if (/matrix|distance|dist/.test(lowerName)) {
         return 'matrix';
@@ -639,12 +480,10 @@ define([
         return 'node';
       }
 
-      // Default to node for tabular data
       if (ext === 'csv' || ext === 'tsv') {
         return 'node';
       }
 
-      // Let MicrobeTrace auto-detect
       return 'auto';
     },
 
@@ -688,7 +527,7 @@ define([
         style: 'color: #17a2b8; margin-bottom: 15px;'
       }, loadingDiv);
       domConstruct.create('span', {
-        innerHTML: 'Loading file information...',
+        textContent: 'Loading file information...',
         style: 'color: #6c757d; font-size: 14px;'
       }, loadingDiv);
       domConstruct.place(loadingDiv, this.contentPane.domNode);
@@ -706,10 +545,10 @@ define([
         className: 'fa icon-warning fa-3x',
         style: 'color: #dc3545; margin-bottom: 15px;'
       }, errorDiv);
-      domConstruct.create('span', {
-        innerHTML: this._escapeHtml(message),
+      var errorSpan = domConstruct.create('span', {
         style: 'color: #dc3545; font-size: 14px;'
       }, errorDiv);
+      errorSpan.textContent = message;
       domConstruct.place(errorDiv, this.contentPane.domNode);
     },
 
@@ -737,6 +576,8 @@ define([
           return 'fa icon-table';
         case 'nwk':
         case 'newick':
+        case 'tre':
+        case 'tree':
           return 'fa icon-tree';
         case 'json':
         case 'microbetrace':
@@ -763,7 +604,7 @@ define([
      * destroy - Clean up resources
      */
     destroy: function () {
-      // Clear stored file content to free memory
+      this._files = null;
       this._fileContent = null;
       this.inherited(arguments);
     }


### PR DESCRIPTION
## Summary
- **Multi-file handoff**: Select multiple files (e.g., tree + metadata CSV) in the workspace browser and pass them all to MicrobeTrace in a single handoff
- **Post-handoff navigation**: After successful handoff, navigate back to the workspace directory instead of staying on the landing page
- **.tre/.tree extension support**: Fixed MicrobeTrace to recognize `.tre` and `.tree` files as Newick trees (previously parsed as CSV link lists)
- **Genome ID precision fix**: Disabled PapaParse `dynamicTyping` so IDs like `28901.36220` are preserved as strings instead of being truncated to `28901.3622`
- **Node.js >=22.12**: Submodule now on `dev` branch (Angular 21) with full partner handoff system

## Changes

### MAAGE-Web
- `WorkspaceBrowser.js` — action button supports `multiple: true` with `allowMultiTypes`, additional files passed as `extraFile=` query params
- `MicrobeTrace.js` — loads multiple files via `getObjects()`, shows file cards for each on landing page, builds multi-file payload, navigates back to workspace after handoff

### BV-BRC-dependencies/MicrobeTrace fork
- `files-plugin.component.ts` — `dynamicTyping: false` for CSV parsing; recognize `.tre`/`.tree` extensions as Newick

## Deployment notes
- Requires Node.js >=22.12.0 (Angular 21)
- After checkout: `git submodule update --init` then `npm run build:microbetrace`

## Test plan
- [ ] Single file: select tree file, click MicrobeTrace, verify handoff and workspace navigation back
- [ ] Multi-file: select tree + metadata CSV, verify both appear on landing page and both load in MicrobeTrace
- [ ] .tre files: verify recognized as Newick trees (not CSV)
- [ ] Genome IDs with trailing zeros (e.g., `28901.36220`): verify preserved in node labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)