### PR TITLE
MicrobeTrace: job result integration, icons, and fixes

### DIFF
--- a/public/js/p3/util/microbeTraceHandoff.js
+++ b/public/js/p3/util/microbeTraceHandoff.js
@@ -1,0 +1,120 @@
+/**
+ * MicrobeTrace Partner Handoff Utility
+ *
+ * Opens MicrobeTrace in a new tab and transfers files via the partner
+ * handoff postMessage protocol.
+ *
+ * Usage:
+ *   require(['p3/util/microbeTraceHandoff'], function (microbeTraceHandoff) {
+ *     microbeTraceHandoff({
+ *       files: [{ name: 'tree.nwk', kind: 'newick', contents: '(A:1,B:2);' }],
+ *       datasetName: 'My Dataset',
+ *       onSuccess: function () { ... },
+ *       onError: function (msg) { ... }
+ *     });
+ *   });
+ */
+define([
+  'dojo/topic'
+], function (
+  Topic
+) {
+  /**
+   * @param {Object} opts
+   * @param {Array} opts.files - Array of { name, kind, contents } objects
+   * @param {string} [opts.datasetName] - Display name for the dataset
+   * @param {Function} [opts.onSuccess] - Called after successful handoff
+   * @param {Function} [opts.onError] - Called on error with message string
+   */
+  return function microbeTraceHandoff(opts) {
+    var files = opts.files || [];
+    if (!files.length) {
+      var msg = 'No files to send to MicrobeTrace.';
+      if (opts.onError) { opts.onError(msg); }
+      Topic.publish('/Notification', { message: msg, type: 'error' });
+      return;
+    }
+
+    var datasetName = opts.datasetName || files.map(function (f) { return f.name; }).join(' + ');
+    var partnerId = 'maage';
+    var nonce = 'maage-' + Date.now() + '-' + Math.random().toString(16).slice(2);
+
+    var payload = {
+      type: 'MT_HANDOFF_TRANSFER',
+      version: 1,
+      partnerId: partnerId,
+      nonce: nonce,
+      metadata: {
+        datasetName: datasetName,
+        sourceApp: 'MAAGE'
+      },
+      files: files
+    };
+
+    console.log('[MicrobeTrace] Opening receiver with partnerId:', partnerId, 'nonce:', nonce, 'files:', files.length);
+
+    var receiverUrl = '/microbetrace/assets/embed/receiver.html?partnerId=' +
+                      encodeURIComponent(partnerId) + '&nonce=' + encodeURIComponent(nonce);
+
+    var receiverWindow = window.open(receiverUrl, '_blank');
+
+    if (!receiverWindow) {
+      var popupMsg = 'Could not open popup. Please allow popups for this site.';
+      if (opts.onError) { opts.onError(popupMsg); }
+      Topic.publish('/Notification', { message: popupMsg, type: 'error' });
+      return;
+    }
+
+    var messageHandler = function (event) {
+      if (!event.data || event.data.type !== 'MT_HANDOFF_READY') {
+        return;
+      }
+      if (event.data.partnerId !== partnerId || event.data.nonce !== nonce) {
+        return;
+      }
+
+      console.log('[MicrobeTrace] Receiver is ready, sending payload');
+      try {
+        receiverWindow.postMessage(payload, '*');
+        console.log('[MicrobeTrace] Payload sent');
+      } catch (e) {
+        console.error('[MicrobeTrace] Failed to send payload:', e);
+      }
+    };
+
+    window.addEventListener('message', messageHandler);
+    setTimeout(function () {
+      window.removeEventListener('message', messageHandler);
+    }, 60000);
+
+    var storedHandler = function (event) {
+      if (!event.data || event.data.type !== 'MT_HANDOFF_TRANSFER' || event.data.status !== 'stored') {
+        return;
+      }
+      if (event.data.partnerId !== partnerId || event.data.nonce !== nonce) {
+        return;
+      }
+
+      console.log('[MicrobeTrace] Handoff stored successfully with ID:', event.data.handoffId);
+      window.removeEventListener('message', storedHandler);
+      window.removeEventListener('message', messageHandler);
+
+      Topic.publish('/Notification', {
+        message: 'MicrobeTrace loaded with ' + datasetName,
+        type: 'success'
+      });
+
+      if (opts.onSuccess) { opts.onSuccess(); }
+    };
+
+    window.addEventListener('message', storedHandler);
+    setTimeout(function () {
+      window.removeEventListener('message', storedHandler);
+    }, 60000);
+
+    Topic.publish('/Notification', {
+      message: 'Opening MicrobeTrace with ' + datasetName,
+      type: 'info'
+    });
+  };
+});

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -6,7 +6,7 @@ define([
   './Confirmation', './SelectionToGroup', 'dijit/Dialog', 'dijit/TooltipDialog',
   'dijit/popup', 'dijit/form/Select', './ContainerActionBar', './GroupExplore', './PerspectiveToolTip',
   'dijit/form/TextBox', './WorkspaceObjectSelector', './PermissionEditor', './ServicesTooltipDialog',
-  'dojo/promise/all', '../util/encodePath', 'dojo/when', 'dojo/request', './TsvCsvFeatures', './RerunUtility', './viewer/JobResult',
+  'dojo/promise/all', '../util/encodePath', '../util/microbeTraceHandoff', 'dojo/when', 'dojo/request', './TsvCsvFeatures', './RerunUtility', './viewer/JobResult',
   'dojo/NodeList-traverse', './app/Homology', './app/GenomeAlignment', './app/PhylogeneticTree'
 ], function (
   declare, BorderContainer, on, query,
@@ -16,7 +16,7 @@ define([
   Confirmation, SelectionToGroup, Dialog, TooltipDialog,
   popup, Select, ContainerActionBar, GroupExplore, PerspectiveToolTipDialog,
   TextBox, WSObjectSelector, PermissionEditor, ServicesTooltipDialog,
-  All, encodePath, when, request, tsvCsvFeatures, rerunUtility, JobResult, NodeList_traverse, Homology, GenomeAlignment, PhylogeneticTree
+  All, encodePath, microbeTraceHandoff, when, request, tsvCsvFeatures, rerunUtility, JobResult, NodeList_traverse, Homology, GenomeAlignment, PhylogeneticTree
 ) {
 
   var mmc = '<div class="wsActionTooltip" rel="dna">Nucleotide</div><div class="wsActionTooltip" rel="protein">Amino Acid</div>';
@@ -1544,6 +1544,47 @@ define([
         }
       }, false);
 
+      // MicrobeTrace action for cgMLST and wgSNP job results
+      this.browserHeader.addAction('ViewInMicrobeTrace', 'fa icon-network fa-2x', {
+        label: 'MICROBETRACE',
+        multiple: false,
+        validTypes: ['CoreGenomeMLST', 'WholeGenomeSNPAnalysis'],
+        tooltip: 'Open results in MicrobeTrace molecular epidemiology tool'
+      }, function (selection) {
+        var widget = self.actionPanel.currentContainerWidget;
+        if (!widget || typeof widget.getMicrobeTraceFiles !== 'function') {
+          alert('MicrobeTrace data is not available for this job result.');
+          return;
+        }
+
+        var mtFiles = widget.getMicrobeTraceFiles();
+        if (!mtFiles.length) {
+          alert('No MicrobeTrace-compatible output files found in this job result.');
+          return;
+        }
+
+        var paths = mtFiles.map(function (f) { return f.path; });
+
+        WorkspaceManager.getObjects(paths, false).then(function (results) {
+          var filesPayload = results.map(function (result, idx) {
+            var content = result.data;
+            if (typeof content === 'object' && content !== null) {
+              content = JSON.stringify(content);
+            }
+            return {
+              name: mtFiles[idx].name,
+              kind: mtFiles[idx].kind,
+              contents: (content || '').trim()
+            };
+          });
+
+          microbeTraceHandoff({ files: filesPayload });
+        }).catch(function (err) {
+          console.error('[MicrobeTrace] Failed to load job result files:', err);
+          alert('Failed to load files for MicrobeTrace: ' + (err.message || err));
+        });
+      }, false);
+
       this.actionPanel.addAction('ExperimentGeneList', 'fa icon-list-unordered fa-2x', {
         label: 'GENES',
         multiple: true,
@@ -2315,6 +2356,12 @@ define([
                   break;
                 case 'Homology':
                   d = 'p3/widget/viewer/BlastJobResult';
+                  break;
+                case 'CoreGenomeMLST':
+                  d = 'p3/widget/viewer/CoreGenomeMLSTResult';
+                  break;
+                case 'WholeGenomeSNPAnalysis':
+                  d = 'p3/widget/viewer/WholeGenomeSNPResult';
                   break;
                 default:
                   console.log('Using the default JobResult viewer. A viewer could not be found for id: ' + id);

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1571,11 +1571,15 @@ define([
             if (typeof content === 'object' && content !== null) {
               content = JSON.stringify(content);
             }
-            return {
+            var file = {
               name: mtFiles[idx].name,
               kind: mtFiles[idx].kind,
               contents: (content || '').trim()
             };
+            if (mtFiles[idx].options) {
+              file.options = mtFiles[idx].options;
+            }
+            return file;
           });
 
           microbeTraceHandoff({ files: filesPayload });

--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1219,8 +1219,8 @@ define([
       }, false);
 
       // MicrobeTrace viewer action for compatible file types
-      this.actionPanel.addAction('ViewMicrobeTrace', 'fa icon-network fa-2x', {
-        label: 'MicrobeTrace',
+      this.actionPanel.addAction('ViewMicrobeTrace', 'icon-microbetrace fa-2x', {
+        label: 'MICROBE<br>TRACE',
         multiple: true,
         allowMultiTypes: true,
         max: 5,
@@ -1545,8 +1545,8 @@ define([
       }, false);
 
       // MicrobeTrace action for cgMLST and wgSNP job results
-      this.browserHeader.addAction('ViewInMicrobeTrace', 'fa icon-network fa-2x', {
-        label: 'MICROBETRACE',
+      this.browserHeader.addAction('ViewInMicrobeTrace', 'icon-microbetrace fa-2x', {
+        label: 'MICROBE<br>TRACE',
         multiple: false,
         validTypes: ['CoreGenomeMLST', 'WholeGenomeSNPAnalysis'],
         tooltip: 'Open results in MicrobeTrace molecular epidemiology tool'

--- a/public/js/p3/widget/viewer/CoreGenomeMLSTResult.js
+++ b/public/js/p3/widget/viewer/CoreGenomeMLSTResult.js
@@ -1,0 +1,51 @@
+/**
+ * Core Genome MLST Job Result Viewer
+ *
+ * Extends the base JobResult viewer with helper methods to locate
+ * MicrobeTrace-compatible output files (tree, distance report, metadata).
+ */
+define([
+  'dojo/_base/declare', './JobResult'
+], function (declare, JobResult) {
+  return declare([JobResult], {
+    containerType: 'CoreGenomeMLST',
+
+    setupResultType: function () {
+      if (this.data.autoMeta.app.id) {
+        this._resultType = this.data.autoMeta.app.id;
+      }
+      this._appLabel = 'Core Genome MLST';
+    },
+
+    /**
+     * getMicrobeTraceFiles - Locate output files for MicrobeTrace handoff
+     *
+     * Returns array of { path, name, kind } where kind is one of:
+     *   'newick', 'link', 'node'
+     */
+    getMicrobeTraceFiles: function () {
+      var files = [];
+      if (!this._resultObjects) return files;
+
+      this._resultObjects.forEach(function (obj) {
+        var name = obj.name || '';
+        var lowerName = name.toLowerCase();
+
+        // Tree file: ends in .tre or .nwk
+        if (lowerName.endsWith('.tre') || lowerName.endsWith('.nwk') || lowerName.endsWith('.newick')) {
+          files.push({ path: obj.path, name: name, kind: 'newick' });
+        }
+        // Distance report: link data
+        else if (lowerName === 'cgmlst_distance.report') {
+          files.push({ path: obj.path, name: name, kind: 'link' });
+        }
+        // Metadata: node data
+        else if (lowerName === 'metadata.tsv' || lowerName === 'bvbrc_metadata.tsv') {
+          files.push({ path: obj.path, name: name, kind: 'node' });
+        }
+      });
+
+      return files;
+    }
+  });
+});

--- a/public/js/p3/widget/viewer/CoreGenomeMLSTResult.js
+++ b/public/js/p3/widget/viewer/CoreGenomeMLSTResult.js
@@ -37,7 +37,7 @@ define([
         }
         // Distance report: link data
         else if (lowerName === 'cgmlst_distance.report') {
-          files.push({ path: obj.path, name: name, kind: 'link' });
+          files.push({ path: obj.path, name: name, kind: 'link', options: { field1: 'genome_id_1', field2: 'genome_id_2', field3: 'distance' } });
         }
         // Metadata: node data
         else if (lowerName === 'metadata.tsv' || lowerName === 'bvbrc_metadata.tsv') {

--- a/public/js/p3/widget/viewer/MicrobeTrace.js
+++ b/public/js/p3/widget/viewer/MicrobeTrace.js
@@ -241,7 +241,7 @@ define([
 
       // MicrobeTrace icon
       domConstruct.create('div', {
-        innerHTML: '<i class="fa icon-network" style="font-size: 64px; color: #17a2b8;"></i>',
+        innerHTML: '<img src="/maage/img/microbetrace-icon.svg" alt="MicrobeTrace" style="width: 64px; height: 64px;">',
         style: 'margin-bottom: 20px;'
       }, card);
 
@@ -494,7 +494,7 @@ define([
           return 'fa icon-tree';
         case 'json':
         case 'microbetrace':
-          return 'fa icon-network';
+          return 'icon-microbetrace';
         default:
           return 'fa icon-file-text-o';
       }

--- a/public/js/p3/widget/viewer/MicrobeTrace.js
+++ b/public/js/p3/widget/viewer/MicrobeTrace.js
@@ -21,6 +21,7 @@ define([
   'dojo/topic',
   '../../WorkspaceManager',
   '../../util/encodePath',
+  '../../util/microbeTraceHandoff',
   '../formatter'
 ], function (
   declare,
@@ -33,6 +34,7 @@ define([
   Topic,
   WorkspaceManager,
   encodePath,
+  microbeTraceHandoff,
   formatter
 ) {
   return declare([BorderContainer], {
@@ -332,15 +334,6 @@ define([
       var _self = this;
       var files = this._files || [];
 
-      if (!files.length) {
-        Topic.publish('/Notification', {
-          message: 'File content not loaded. Please try again.',
-          type: 'error'
-        });
-        return;
-      }
-
-      // Build files array for the payload
       var filesPayload = files.map(function (f) {
         return {
           name: f.filename,
@@ -349,93 +342,13 @@ define([
         };
       });
 
-      var datasetName = files.map(function (f) { return f.filename; }).join(' + ');
-
-      var partnerId = 'maage';
-      var nonce = 'maage-' + Date.now() + '-' + Math.random().toString(16).slice(2);
-
-      var payload = {
-        type: 'MT_HANDOFF_TRANSFER',
-        version: 1,
-        partnerId: partnerId,
-        nonce: nonce,
-        metadata: {
-          datasetName: datasetName,
-          sourceApp: 'MAAGE'
-        },
-        files: filesPayload
-      };
-
-      console.log('[MicrobeTrace] Opening receiver with partnerId:', partnerId, 'nonce:', nonce, 'files:', filesPayload.length);
-
-      var receiverUrl = '/microbetrace/assets/embed/receiver.html?partnerId=' +
-                        encodeURIComponent(partnerId) + '&nonce=' + encodeURIComponent(nonce);
-
-      var receiverWindow = window.open(receiverUrl, '_blank');
-
-      if (!receiverWindow) {
-        Topic.publish('/Notification', {
-          message: 'Could not open popup. Please allow popups for this site.',
-          type: 'error'
-        });
-        return;
-      }
-
-      // Listen for the READY message from the receiver
-      var messageHandler = function (event) {
-        if (!event.data || event.data.type !== 'MT_HANDOFF_READY') {
-          return;
+      microbeTraceHandoff({
+        files: filesPayload,
+        onSuccess: function () {
+          if (_self._workspaceDir) {
+            Topic.publish('/navigate', { href: '/workspace' + encodePath(_self._workspaceDir) });
+          }
         }
-        if (event.data.partnerId !== partnerId || event.data.nonce !== nonce) {
-          return;
-        }
-
-        console.log('[MicrobeTrace] Receiver is ready, sending payload');
-        try {
-          receiverWindow.postMessage(payload, '*');
-          console.log('[MicrobeTrace] Payload sent');
-        } catch (e) {
-          console.error('[MicrobeTrace] Failed to send payload:', e);
-        }
-      };
-
-      window.addEventListener('message', messageHandler);
-      setTimeout(function () {
-        window.removeEventListener('message', messageHandler);
-      }, 60000);
-
-      // Listen for stored confirmation and navigate back to workspace
-      var storedHandler = function (event) {
-        if (!event.data || event.data.type !== 'MT_HANDOFF_TRANSFER' || event.data.status !== 'stored') {
-          return;
-        }
-        if (event.data.partnerId !== partnerId || event.data.nonce !== nonce) {
-          return;
-        }
-
-        console.log('[MicrobeTrace] Handoff stored successfully with ID:', event.data.handoffId);
-        window.removeEventListener('message', storedHandler);
-        window.removeEventListener('message', messageHandler);
-
-        Topic.publish('/Notification', {
-          message: 'MicrobeTrace loaded with ' + datasetName,
-          type: 'success'
-        });
-
-        // Navigate back to the workspace directory
-        if (_self._workspaceDir) {
-          Topic.publish('/navigate', { href: '/workspace' + encodePath(_self._workspaceDir) });
-        }
-      };
-
-      window.addEventListener('message', storedHandler);
-      setTimeout(function () {
-        window.removeEventListener('message', storedHandler);
-      }, 60000);
-
-      Topic.publish('/Notification', {
-        message: 'Opening MicrobeTrace with ' + datasetName,
-        type: 'info'
       });
     },
 

--- a/public/js/p3/widget/viewer/WholeGenomeSNPResult.js
+++ b/public/js/p3/widget/viewer/WholeGenomeSNPResult.js
@@ -1,0 +1,82 @@
+/**
+ * Whole Genome SNP Analysis Job Result Viewer
+ *
+ * Extends the base JobResult viewer with helper methods to locate
+ * MicrobeTrace-compatible output files. Uses recursive folder listing
+ * to find Newick tree files in nested subdirectories.
+ */
+define([
+  'dojo/_base/declare',
+  './JobResult',
+  '../../WorkspaceManager'
+], function (declare, JobResult, WorkspaceManager) {
+  return declare([JobResult], {
+    containerType: 'WholeGenomeSNPAnalysis',
+
+    _allResultObjects: null,
+
+    _setDataAttr: function (data) {
+      this.data = data;
+      if (data.autoMeta.parameters.output_path != data.path) {
+        for (var outfile of data.autoMeta.output_files) {
+          outfile[0] = outfile[0].replace(new RegExp('^' + data.autoMeta.parameters.output_path), data.path);
+        }
+      }
+      this._hiddenPath = data.path + '.' + data.name;
+      var _self = this;
+
+      WorkspaceManager.getObject(this._hiddenPath, true).otherwise(function () {
+        // Hidden folder not found — handled by base class pattern
+      });
+
+      // Use recursive listing to find files in nested subdirectories
+      WorkspaceManager.getFolderContents(this._hiddenPath, true, true)
+        .then(function (objs) {
+          _self._allResultObjects = objs;
+          // Set _resultObjects to the full recursive listing
+          // so the file browser shows all files
+          _self._resultObjects = objs;
+          _self.setupResultType();
+          _self.refresh();
+        });
+    },
+
+    setupResultType: function () {
+      if (this.data.autoMeta.app.id) {
+        this._resultType = this.data.autoMeta.app.id;
+      }
+      this._appLabel = 'Whole Genome SNP Analysis';
+    },
+
+    /**
+     * getMicrobeTraceFiles - Locate output files for MicrobeTrace handoff
+     *
+     * Returns array of { path, name, kind } where kind is one of:
+     *   'newick', 'link', 'node'
+     */
+    getMicrobeTraceFiles: function () {
+      var files = [];
+      var objs = this._allResultObjects || this._resultObjects || [];
+
+      objs.forEach(function (obj) {
+        var name = obj.name || '';
+        var lowerName = name.toLowerCase();
+
+        // Maximum Likelihood tree only
+        if (lowerName === 'tree.snps_all.ml.tre') {
+          files.push({ path: obj.path, name: name, kind: 'newick' });
+        }
+        // Distance report: link data
+        else if (lowerName === 'all_ksnpdist.report') {
+          files.push({ path: obj.path, name: name, kind: 'link' });
+        }
+        // Metadata: node data
+        else if (lowerName === 'all_metadata.tsv') {
+          files.push({ path: obj.path, name: name, kind: 'node' });
+        }
+      });
+
+      return files;
+    }
+  });
+});

--- a/public/js/p3/widget/viewer/WholeGenomeSNPResult.js
+++ b/public/js/p3/widget/viewer/WholeGenomeSNPResult.js
@@ -62,16 +62,16 @@ define([
         var name = obj.name || '';
         var lowerName = name.toLowerCase();
 
-        // Maximum Likelihood tree only
-        if (lowerName === 'tree.snps_all.ml.tre') {
+        // Maximum Likelihood tree from Core_SNPs
+        if (lowerName === 'tree.snps_all.ml.tre' && obj.path.indexOf('Core_SNPs') > -1) {
           files.push({ path: obj.path, name: name, kind: 'newick' });
         }
-        // Distance report: link data
-        else if (lowerName === 'all_ksnpdist.report') {
-          files.push({ path: obj.path, name: name, kind: 'link' });
+        // Distance report from Core_SNPs: link data
+        else if (lowerName === 'core_ksnpdist.report') {
+          files.push({ path: obj.path, name: name, kind: 'link', options: { field1: 'genome_id_1', field2: 'genome_id_2', field3: 'distance' } });
         }
         // Metadata: node data
-        else if (lowerName === 'all_metadata.tsv') {
+        else if (lowerName === 'metadata.tsv') {
           files.push({ path: obj.path, name: name, kind: 'node' });
         }
       });

--- a/public/maage/css/dist/maage.css
+++ b/public/maage/css/dist/maage.css
@@ -787,10 +787,6 @@ video {
   margin-top: 0.375rem;
 }
 
-.mt-10 {
-  margin-top: 2.5rem;
-}
-
 .mt-16 {
   margin-top: 4rem;
 }
@@ -877,10 +873,6 @@ video {
 
 .h-10 {
   height: 2.5rem;
-}
-
-.h-12 {
-  height: 3rem;
 }
 
 .h-24 {
@@ -1087,16 +1079,6 @@ video {
 
 .transform {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-@keyframes pulse {
-  50% {
-    opacity: .5;
-  }
-}
-
-.animate-pulse {
-  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 .cursor-default {

--- a/public/maage/css/src/styles.css
+++ b/public/maage/css/src/styles.css
@@ -968,6 +968,21 @@ div.ActionButton.fa-2x {
   height: 30px !important;
 }
 
+div.ActionButton.icon-microbetrace {
+  background-image: url('/maage/img/microbetrace-icon.svg');
+  background-size: 24px 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 30px !important;
+  height: 30px !important;
+  margin: 1px auto 0 auto;
+  display: block;
+}
+
+.BrowserHeader div.ActionButton.icon-microbetrace {
+  background-image: url('/maage/img/microbetrace-icon-dark.svg');
+}
+
 div#maage-page {
   width: 100%;
 }

--- a/public/maage/img/microbetrace-icon-dark.svg
+++ b/public/maage/img/microbetrace-icon-dark.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- Connecting lines -->
+  <line x1="16" y1="14" x2="7" y2="6" stroke="#34698e" stroke-width="1.5"/>
+  <line x1="16" y1="14" x2="26" y2="7" stroke="#34698e" stroke-width="1.5"/>
+  <line x1="16" y1="14" x2="8" y2="26" stroke="#34698e" stroke-width="1.5"/>
+  <line x1="16" y1="14" x2="26" y2="24" stroke="#34698e" stroke-width="1.5"/>
+  <line x1="7" y1="6" x2="26" y2="7" stroke="#34698e" stroke-width="1"/>
+  <line x1="8" y1="26" x2="26" y2="24" stroke="#34698e" stroke-width="1"/>
+  <!-- Central node -->
+  <circle cx="16" cy="14" r="5.5" fill="#34698e"/>
+  <!-- Top-left node -->
+  <circle cx="7" cy="6" r="3" fill="#34698e"/>
+  <!-- Top-right node -->
+  <circle cx="26" cy="7" r="2.5" fill="#34698e"/>
+  <!-- Bottom-left node -->
+  <circle cx="8" cy="26" r="3" fill="#34698e"/>
+  <!-- Bottom-right node -->
+  <circle cx="26" cy="24" r="2.5" fill="#34698e"/>
+</svg>

--- a/public/maage/img/microbetrace-icon.svg
+++ b/public/maage/img/microbetrace-icon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- Connecting lines -->
+  <line x1="16" y1="14" x2="7" y2="6" stroke="#fff" stroke-width="1.5"/>
+  <line x1="16" y1="14" x2="26" y2="7" stroke="#fff" stroke-width="1.5"/>
+  <line x1="16" y1="14" x2="8" y2="26" stroke="#fff" stroke-width="1.5"/>
+  <line x1="16" y1="14" x2="26" y2="24" stroke="#fff" stroke-width="1.5"/>
+  <line x1="7" y1="6" x2="26" y2="7" stroke="#fff" stroke-width="1"/>
+  <line x1="8" y1="26" x2="26" y2="24" stroke="#fff" stroke-width="1"/>
+  <!-- Central node -->
+  <circle cx="16" cy="14" r="5.5" fill="#fff"/>
+  <!-- Top-left node -->
+  <circle cx="7" cy="6" r="3" fill="#fff"/>
+  <!-- Top-right node -->
+  <circle cx="26" cy="7" r="2.5" fill="#fff"/>
+  <!-- Bottom-left node -->
+  <circle cx="8" cy="26" r="3" fill="#fff"/>
+  <!-- Bottom-right node -->
+  <circle cx="26" cy="24" r="2.5" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- **Job result viewers**: Add MicrobeTrace action button to cgMLST and wgSNP job result pages, passing tree, distance report, and metadata files directly to MicrobeTrace
- **Custom icon**: SVG network icon matching the MicrobeTrace logo, white for sidebar and dark for header bar
- **Column mapping**: Distance reports specify genome_id_1/genome_id_2/distance fields so MicrobeTrace uses the correct source/target columns
- **Shared handoff utility**: Extracted postMessage handoff flow into reusable `microbeTraceHandoff.js`
- **wgSNP**: Uses Core_SNPs ML tree and core_kSNPdist.report

## New files
- `public/js/p3/util/microbeTraceHandoff.js` — shared handoff utility
- `public/js/p3/widget/viewer/CoreGenomeMLSTResult.js` — cgMLST job result viewer
- `public/js/p3/widget/viewer/WholeGenomeSNPResult.js` — wgSNP job result viewer (recursive folder listing)
- `public/maage/img/microbetrace-icon.svg` — white icon for sidebar
- `public/maage/img/microbetrace-icon-dark.svg` — dark icon for header

## Modified files
- `WorkspaceBrowser.js` — register viewers, add action button, use new icon
- `MicrobeTrace.js` — refactored to use shared handoff utility, use SVG icon
- `styles.css` — icon CSS classes

## Test plan
- [ ] Open cgMLST job result — verify MicrobeTrace icon appears in header
- [ ] Click icon — verify tree + distance report + metadata load in MicrobeTrace
- [ ] Open wgSNP job result — verify MicrobeTrace icon appears
- [ ] Click icon — verify ML tree + core distance report + metadata load
- [ ] Verify distance report uses genome_id_1/genome_id_2 as source/target columns
- [ ] Verify icon is white on sidebar, dark on header bar
- [ ] Workspace browser: multi-select tree + CSV still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)