### PR TITLE
MicrobeTrace: SNP set dropdown for wgSNP, default-view fix

### DIFF
--- a/public/js/p3/widget/WorkspaceBrowser.js
+++ b/public/js/p3/widget/WorkspaceBrowser.js
@@ -1647,20 +1647,8 @@ define([
         }
       }, false);
 
-      // MicrobeTrace action for cgMLST and wgSNP job results
-      this.browserHeader.addAction('ViewInMicrobeTrace', 'icon-microbetrace', {
-        label: 'MICROBE<br>TRACE',
-        multiple: false,
-        validTypes: ['CoreGenomeMLST', 'WholeGenomeSNPAnalysis'],
-        tooltip: 'Open results in MicrobeTrace molecular epidemiology tool'
-      }, function (selection) {
-        var widget = self.actionPanel.currentContainerWidget;
-        if (!widget || typeof widget.getMicrobeTraceFiles !== 'function') {
-          alert('MicrobeTrace data is not available for this job result.');
-          return;
-        }
-
-        var mtFiles = widget.getMicrobeTraceFiles();
+      // Helper: load files and launch MicrobeTrace handoff
+      function launchMicrobeTraceWithFiles(mtFiles) {
         if (!mtFiles.length) {
           alert('No MicrobeTrace-compatible output files found in this job result.');
           return;
@@ -1668,7 +1656,6 @@ define([
 
         var paths = mtFiles.map(function (f) { return f.path; });
 
-        // Load files and default style in parallel
         All([
           WorkspaceManager.getObjects(paths, false),
           request('/maage/config/microbetrace-default-style.json', { handleAs: 'json', headers: { 'Accept': 'application/json' } })
@@ -1699,6 +1686,76 @@ define([
         }).catch(function (err) {
           console.error('[MicrobeTrace] Failed to load job result files:', err);
           alert('Failed to load files for MicrobeTrace: ' + (err.message || err));
+        });
+      }
+
+      // SNP set selection dropdown for wgSNP jobs
+      var snpSetTT = new TooltipDialog({
+        content: '',
+        onMouseLeave: function () {
+          popup.close(snpSetTT);
+        }
+      });
+
+      on(snpSetTT.domNode, 'click', function (evt) {
+        var target = evt.target;
+        while (target && !target.attributes.rel && target !== snpSetTT.domNode) {
+          target = target.parentNode;
+        }
+        if (!target || !target.attributes || !target.attributes.rel) return;
+
+        popup.close(snpSetTT);
+        var snpSet = target.attributes.rel.value;
+        var widget = self.actionPanel.currentContainerWidget;
+        if (widget && typeof widget.getMicrobeTraceFiles === 'function') {
+          launchMicrobeTraceWithFiles(widget.getMicrobeTraceFiles(snpSet));
+        }
+      });
+
+      // MicrobeTrace action for cgMLST job results (direct launch)
+      this.browserHeader.addAction('ViewInMicrobeTrace', 'icon-microbetrace', {
+        label: 'MICROBE<br>TRACE',
+        multiple: false,
+        validTypes: ['CoreGenomeMLST'],
+        tooltip: 'Open results in MicrobeTrace molecular epidemiology tool'
+      }, function (selection) {
+        var widget = self.actionPanel.currentContainerWidget;
+        if (!widget || typeof widget.getMicrobeTraceFiles !== 'function') {
+          alert('MicrobeTrace data is not available for this job result.');
+          return;
+        }
+        launchMicrobeTraceWithFiles(widget.getMicrobeTraceFiles());
+      }, false);
+
+      // MicrobeTrace action for wgSNP job results (dropdown for SNP set selection)
+      this.browserHeader.addAction('ViewInMicrobeTraceSNP', 'icon-microbetrace', {
+        label: 'MICROBE<br>TRACE',
+        multiple: false,
+        validTypes: ['WholeGenomeSNPAnalysis'],
+        tooltip: 'Open results in MicrobeTrace - select SNP set'
+      }, function (selection) {
+        var widget = self.actionPanel.currentContainerWidget;
+        if (!widget || typeof widget.getAvailableSNPSets !== 'function') {
+          alert('MicrobeTrace data is not available for this job result.');
+          return;
+        }
+
+        var sets = widget.getAvailableSNPSets();
+        if (!sets.length) {
+          alert('No SNP sets with tree files found in this job result.');
+          return;
+        }
+
+        // Build dropdown content
+        var content = sets.map(function (s) {
+          return '<div class="wsActionTooltip" rel="' + s.id + '">' + s.label + '</div>';
+        }).join('');
+        snpSetTT.set('content', content);
+
+        popup.open({
+          popup: snpSetTT,
+          around: self.browserHeader._actions.ViewInMicrobeTraceSNP.button,
+          orient: ['below']
         });
       }, false);
 

--- a/public/js/p3/widget/viewer/WholeGenomeSNPResult.js
+++ b/public/js/p3/widget/viewer/WholeGenomeSNPResult.js
@@ -15,6 +15,13 @@ define([
 
     _allResultObjects: null,
 
+    // SNP set definitions: folder name, distance report name
+    _snpSets: {
+      'All': { folder: 'All_SNPs', report: 'all_ksnpdist.report' },
+      'Majority': { folder: 'Majority_SNPs', report: 'majority_ksnpdist.report' },
+      'Core': { folder: 'Core_SNPs', report: 'core_ksnpdist.report' }
+    },
+
     _setDataAttr: function (data) {
       this.data = data;
       if (data.autoMeta.parameters.output_path != data.path) {
@@ -26,15 +33,13 @@ define([
       var _self = this;
 
       WorkspaceManager.getObject(this._hiddenPath, true).otherwise(function () {
-        // Hidden folder not found — handled by base class pattern
+        // Hidden folder not found
       });
 
       // Use recursive listing to find files in nested subdirectories
       WorkspaceManager.getFolderContents(this._hiddenPath, true, true)
         .then(function (objs) {
           _self._allResultObjects = objs;
-          // Set _resultObjects to the full recursive listing
-          // so the file browser shows all files
           _self._resultObjects = objs;
           _self.setupResultType();
           _self.refresh();
@@ -49,32 +54,61 @@ define([
     },
 
     /**
+     * getAvailableSNPSets - Return which SNP sets are available in this job
+     *
+     * Returns array of { id, label } for sets that have tree files
+     */
+    getAvailableSNPSets: function () {
+      var objs = this._allResultObjects || this._resultObjects || [];
+      var available = [];
+      var sets = this._snpSets;
+
+      Object.keys(sets).forEach(function (setId) {
+        var folder = sets[setId].folder;
+        var hasTree = objs.some(function (obj) {
+          return obj.name && obj.name.toLowerCase().endsWith('.ml.tre') &&
+                 obj.path && obj.path.indexOf(folder) > -1;
+        });
+        if (hasTree) {
+          available.push({ id: setId, label: setId + ' SNPs' });
+        }
+      });
+
+      return available;
+    },
+
+    /**
      * getMicrobeTraceFiles - Locate output files for MicrobeTrace handoff
      *
-     * Returns array of { path, name, kind } where kind is one of:
-     *   'newick', 'link', 'node'
+     * @param {string} [snpSet='Core'] - Which SNP set to use: 'All', 'Majority', or 'Core'
+     * Returns array of { path, name, kind } objects
      */
-    getMicrobeTraceFiles: function () {
+    getMicrobeTraceFiles: function (snpSet) {
+      snpSet = snpSet || 'Core';
+      var setDef = this._snpSets[snpSet];
+      if (!setDef) {
+        console.error('[WholeGenomeSNP] Unknown SNP set:', snpSet);
+        return [];
+      }
+
       var files = [];
       var objs = this._allResultObjects || this._resultObjects || [];
+      var folder = setDef.folder;
+      var reportName = setDef.report;
 
-      console.log('[WholeGenomeSNP] getMicrobeTraceFiles scanning', objs.length, 'objects');
       objs.forEach(function (obj) {
         var name = obj.name || '';
         var lowerName = name.toLowerCase();
-        if (lowerName.endsWith('.tre') || lowerName.endsWith('.report') || lowerName.endsWith('.tsv')) {
-          console.log('[WholeGenomeSNP] candidate:', name, 'path:', obj.path);
-        }
 
-        // Maximum Likelihood tree from Core_SNPs
-        if (lowerName.endsWith('.ml.tre') && obj.path.indexOf('Core_SNPs') > -1) {
+        // Maximum Likelihood tree from the selected SNP set
+        if (lowerName.endsWith('.ml.tre') && obj.path.indexOf(folder) > -1) {
           files.push({ path: obj.path, name: name, kind: 'newick' });
         }
-        // Distance report from Core_SNPs: link data
-        else if (lowerName === 'core_ksnpdist.report') {
+        // Distance report from the selected SNP set
+        else if (lowerName === reportName) {
           files.push({ path: obj.path, name: name, kind: 'link', options: { field1: 'genome_id_1', field2: 'genome_id_2', field3: 'distance' } });
         }
-        // Metadata: node data
+        // Metadata (always from job root)
         else if (lowerName === 'metadata.tsv') {
           files.push({ path: obj.path, name: name, kind: 'node' });
         }


### PR DESCRIPTION
## Summary
- SNP set dropdown: wgSNP job MicrobeTrace button now shows a dropdown to select All SNPs, Majority SNPs, or Core SNPs
- Default view fix: Set DOM element directly before launch so style default view takes effect
- Updated submodule: MicrobeTrace fork at 4363162d

## Test plan
- Open wgSNP job result, click MicrobeTrace, verify dropdown with SNP set options
- Select each SNP set, verify correct tree and distance report load
- Open cgMLST job result, verify direct launch (no dropdown)
- Verify Phylogenetic Tree opens as default view