### PR TITLE
Searches and Tools pages: align content with navbar

### DIFF
--- a/views/pages/searches.ejs
+++ b/views/pages/searches.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
 
   <head>
-    <title>Advanced Searches | Midwest Alliance for Applied Genomic Epidemiology</title>
+    <title>Searches | Midwest Alliance for Applied Genomic Epidemiology</title>
     <%- include('../head') %>
   </head>
 
@@ -42,98 +42,40 @@
               </style>
               <div class="w-[95%] md:w-[85%] lg:w-[75%] mx-auto">
                 <h1 id="privacy-policy" class="text-2xl font-semibold font-poppins pt-4 pb-6">
-                  Advanced Searches</h1>
+                  Searches</h1>
                 <div class="searches">
-                  <h3>Taxa</h3>
-
+                  <h3><a href="/searches/TaxaSearch">Taxa</a></h3>
                   <p>
                     Search for taxa using taxon id or name and jump to taxon level pages to access relevant data and
                     analysis tools.
                   </p>
-                  <ul>
-                    <li><a href="/searches/TaxaSearch">Taxa Search</a></li>
-                    <li><a href="https://www.maage-brc.org/docs/quick_references/searches_menu.html">Quick Reference Guide</a></li>
-                  </ul>
                   <br>
-                  <h3>Genomes</h3>
+                  <h3><a href="/searches/GenomeSearch">Genomes</a></h3>
                   <p>
                     Search for microbial or viral genomes (or genome segments for segmented viruses) of interest using
                     generic keywords, genome id/name, pathogen group, various metadata attributes, or database
                     identifiers.
                   </p>
-                  <ul>
-                    <li><a href="/searches/GenomeSearch">Genome Search</a></li>
-                    <li><a href="https://www.maage-brc.org/docs/quick_references/searches_menu.html">Quick Reference Guide</a></li>
-                  </ul>
                   <br>
-                  <h3>AMR Phenotypes</h3>
+                  <h3><a href="/searches/AMRPhenotypeSearch">AMR Phenotypes</a></h3>
                   <p>
                     Search for antimicrobial resistance (AMR) phenotype data associated with microbial genomes of interest
                     using antibiotic, resistant phenotype, evidence, and various genome metadata attributes.
                   </p>
-                  <ul>
-                    <li><a href="/searches/AMRPhenotypeSearch">AMR Phenotype Search</a></li>
-                    <li><a href="https://www.maage-brc.org/docs/quick_references/searches_menu.html">Quick Reference Guide</a></li>
-                  </ul>
                   <br>
-                  <h3>Features</h3>
+                  <h3><a href="/searches/GenomicFeatureSearch">Features</a></h3>
                   <p>
                     Search for proteins of interest (resulting from CDS and mature peptide features) using generic
                     keywords, pathogen group, various genome metadata attributes, protein product, or database
                     identifiers.
                   </p>
-                  <ul>
-                    <li><a href="/searches/GenomicFeatureSearch">Genomic Feature Search</a></li>
-                    <li><a href="https://www.maage-brc.org/docs/quick_references/searches_menu.html">Quick Reference Guide</a></li>
-                  </ul> <br>
-                  <h3>Proteins</h3>
-                  <p>
-                    Search for proteins of interest (resulting from CDS and mature peptide features) using generic
-                    keywords, pathogen group, various genome metadata attributes, protein product, or database
-                    identifiers.
-                  </p>
-                  <ul>
-                    <li><a href="/searches/ProteinsSearch">Protein Search</a></li>
-                    <li><a href="https://www.maage-brc.org/docs/quick_references/searches_menu.html">Quick Reference Guide</a></li>
-                  </ul> <br>
-                  <h3>Specialty Genes</h3>
+                  <br>
+                  <h3><a href="/searches/SpecialtyGeneSearch">Specialty Genes</a></h3>
                   <p>
                     Search for specialty genes annotated in microbial genomes, such as antimicrobial resistance genes,
                     virulence factors, essential genes, drug targets, and human homologs. Search using generic keywords,
                     pathogen group, property, source database, or protein product.
                   </p>
-                  <ul>
-                    <li><a href="/searches/SpecialtyGeneSearch">Specialty Gene Search</a></li>
-                    <li><a href="https://www.maage-brc.org/docs/quick_references/searches_menu.html">Quick Reference Guide</a></li>
-                  </ul> <br>
-
-                  <h3>Protein Structures</h3>
-                  <p>
-                    Search for experimentally characterized protein structures of interest using generic keywords,
-                    pathogen group or taxon name, PDB id, description, or protein product.
-                  </p>
-                  <ul>
-                    <li><a href="/searches/ProteinStructureSearch">Protein Structure Search</a></li>
-                    <li><a href="https://www.maage-brc.org/docs/quick_references/searches_menu.html">Quick Reference Guide</a></li>
-                  </ul> <br>
-                  <h3>Pathways</h3>
-                  <p>
-                    Search for metabolic pathways annotated in microbial genomes using generic keywords, pathogen group
-                    or taxon name, pathway id, name, product, or EC number.
-                  </p>
-                  <ul>
-                    <li><a href="/searches/PathwaySearch">Pathway Search</a></li>
-                    <li><a href="https://www.maage-brc.org/docs/quick_references/searches_menu.html">Quick Reference Guide</a></li>
-                  </ul> <br>
-                  <h3>Subsystems</h3>
-                  <p>
-                    Search for subsystems annotated in microbial genomes using generic keywords, pathogen group or taxon
-                    name, subsystem id, name, or functional role.
-                  </p>
-                  <ul>
-                    <li><a href="/searches/SubsystemSearch">Subsystem Search</a></li>
-                    <li><a href="https://www.maage-brc.org/docs/quick_references/searches_menu.html">Quick Reference Guide</a></li>
-                  </ul>
 
                 </div>
 

--- a/views/pages/tools.ejs
+++ b/views/pages/tools.ejs
@@ -29,417 +29,149 @@
                                     font-size: 16px;
                                     line-height: 1.5;
                                 }
+
+                                h3 {
+                                    margin: 0;
+                                    padding: 0;
+                                    margin-bottom: 4px;
+                                }
+
+                                li {
+                                    margin-bottom: 2px;
+                                }
                             </style>
                             <div class="w-[95%] md:w-[85%] lg:w-[75%] mx-auto">
                                 <h1 id="privacy-policy" class="text-2xl font-semibold font-poppins pt-4 pb-6">
                                     Tools</h1>
-                                <div class="tools">
+                                <div class="searches">
 
-                                    <div class="tools-container" style="overflow: visible; margin-bottom: 40px;">
-                                        <div class="tools-flex" style="display: flex; flex-wrap: wrap; gap: 20px;">
-                                            <div class="tools-flex-left"
-                                                style="flex: 1; min-width: 300px; max-width: 100%;">
-                                                <h3>Assembly</h3>
-                                                <p>
-                                                    The Genome Assembly Service allows single or multiple assemblers to
-                                                    be invoked to compare results. The service attempts to select the
-                                                    best assembly.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/Assembly2">Genome Assembly</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/quick_references/services/genome_assembly_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/tutorial/genome_assembly/assembly.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Annotation</h3>
-                                                <p>
-                                                    The Genome Annotation Service provides annotation of genomic
-                                                    features using the RAST tool kit (RASTtk) for bacteria and VIGOR4
-                                                    for viruses. The service accepts a FASTA formatted contig file and
-                                                    an annotation recipe based on taxonomy to provide an annotated
-                                                    genome.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/Annotation">Genome Annotation</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/quick_references/services/genome_annotation_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/tutorial/genome_annotation/genome_annotation.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Comparative Systems</h3>
-                                                <p>
-                                                    The Comparative Systems Service allows users to identify a set of
-                                                    pathways, subsystems and protein families for given genome(s) or
-                                                    genome group(s).
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/ComparativeSystems">Comparative Systems</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/quick_references/services/comparative_systems.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/tutorial/comparative_systems/comparative_systems.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Comprehenvsive Genome Analysis</h3>
-                                                <p>
-                                                    The Comprehensive Genome Analysis Service provides a streamlined
-                                                    analysis "meta-service" that accepts raw reads and performs a
-                                                    comprehensive analysis including assembly, annotation,
-                                                    identification of nearest neighbors, a basic comparative analysis
-                                                    that includes a subsystem summary, phylogenetic tree, and the
-                                                    features that distinguish the genome from its nearest neighbors.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/ComprehensiveGenomeAnalysis">Comprehensive Genome
-                                                            Analysis</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/quick_references/services/comprehensive_genome_analysis_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/tutorial/comprehensive_genome_analysis/comprehensive_genome_analysis.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>BLAST</h3>
-                                                <p>
-                                                    The BLAST service uses BLAST (Basic Local Aligment Search Tool) to
-                                                    search against public or private genomes or other databases using
-                                                    DNA or protein sequence(s).
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/Homology">BLAST</a></li>
-                                                    <li><a href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/quick_references/services/blast.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/tutorial/blast/blast.html">Tutorial</a></li>
-                                                </ul>
-                                                <h3>SARS-CoV-2 Genome Assembly and Annotation</h3>
-                                                <p>
-                                                    The SARS-CoV-2 Genome Assembly and Annotation Service provides a
-                                                    streamlined "meta-service" that accepts raw reads and performs
-                                                    genome assembly, annotation, and variation analysis.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/ComprehensiveSARS2Analysis">SARS-CoV-2 Genome
-                                                            Assembly and Annotation</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/quick_references/services/sars_cov_2_assembly_annotation_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/tutorial/sars_cov_2_assembly_annotation/sars_cov_2_assembly_annotation.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Similar Genome Finder</span></h3>
-                                                <p>
-                                                    The Similar Genome Finder Service will find similar public genomes
-                                                    in PATRIC or compute genome distance estimation using <a
-                                                        href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4915045/">Mash/MinHash</a>.
-                                                    It returns a set of genomes matching the specified similarity
-                                                    criteria.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/GenomeDistance">Similar Genome Finder</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/quick_references/services/similar_genome_finder_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.orghttps://www.maage-brc.org/docs/tutorial/similar_genome_finder/similar_genome_finder.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Meta-CATS</h3>
-                                                <p>
-                                                    The meta-CATS tool looks for positions that significantly differ
-                                                    between user-defined groups of sequences. However, biological biases
-                                                    due to covariation, codon biases, and differences in genotype,
-                                                    geography, time of isolation, or others may affect the robustness of
-                                                    the underlying statistical assumptions.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/MetaCATS">Metadata-driven Comparative Analysis
-                                                            Tool (meta-CATS)</a></li>
-                                                    <li><a href="https://www.maage-brc.org/docs/quick_references/services/metacats.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a href="https://www.maage-brc.org/docs/tutorial/metacats/metacats.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Phylogenetic Tree <span style="font-style: italic;">(B)</span></h3>
-                                                <p>
-                                                    The Phylogenetic Tree Building Service enables construction of
-                                                    custom phylogenetic trees for user-selected genomes.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/PhylogeneticTree">Phylogen Tree Building</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/phylogenetic_tree_building_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/phylogenetic_tree/phylogenetic_tree.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Genome Alignment <span style="font-style: italic;">(B)</span></h3>
-                                                <p>
-                                                    The Whole Genome Alignment Service aligns genomes using <a
-                                                        class="navigationLinkOut"
-                                                        href="https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0011147">progressiveMauve</a>.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/GenomeAlignment">Genome Alignment (Mauve)</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/genome_alignment_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/genome_alignment/genome_alignment.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Primer Design</h3>
-                                                <p>
-                                                    The Primer Design Service utilizes Primer3 to design primers from a
-                                                    given input sequence under a variety of temperature, size, and
-                                                    concentration constraints.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/PrimerDesign">Primer Design</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/primer_design_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/primer_design/primer_design.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Variation Analysis <span style="font-style: italic;">(B)</span></h3>
-                                                <p>
-                                                    The Variation Analysis Service can be used to identify and annotate
-                                                    sequence variations.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/Variation">Variation Analysis</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/variation_analysis_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/variation_analysis/variation_analysis.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Tn-Seq Analysis <span style="font-style: italic;">(B)</span></h3>
-                                                <p>
-                                                    The Tn-Seq Analysis Service facilitates determination of essential
-                                                    and conditionally essential regions in bacterial genomes from data
-                                                    generated from transposon insertion sequencing (Tn-Seq) experiments.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/Tnseq">Tn-Seq Analysis</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/tn_seq_analysis_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a href="https://www.maage-brc.org/docs/tutorial/tn-seq/tn-seq.html">Tutorial</a></li>
-                                                </ul>
-                                                <h3>Subspecies Classification <span
-                                                        style="font-style: italic;">(V)</span></h3>
-                                                <p>
-                                                    The sub-species classification tool assigns the genotype/subtype of
-                                                    a virus, based on the genotype/subtype assignments maintained by the
-                                                    International Committee on Taxonomy of Viruses (ICTV). This tool
-                                                    infers the genotype/subtype for a query sequence from its position
-                                                    within a reference tree. The service uses the pplacer tool with a
-                                                    reference tree and reference alignment and includes the query
-                                                    sequence as input. Interpretation of the pplacer result is handled
-                                                    by Cladinator. Link to <a class="navigationLinkOut"
-                                                        href="https://matsen.fhcrc.org/pplacer">pplacer</a> and <a
-                                                        class="navigationLinkOut"
-                                                        href="https://github.com/cmzmasek/forester/blob/master/forester/java/src/org/forester/application/cladinator.java">Cladinator</a>.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/SubspeciesClassification">Subspecies
-                                                            Classification</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/subspecies_classification_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/subspecies_classification/subspecies_classification.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>MSA and SNP Alignment</h3>
-                                                <p>
-                                                    The multiple sequence alignment service with variation and SNP
-                                                    analysis can be used with feature groups, fasta files, aligned fasta
-                                                    files, and user input fasta records. If a single alignment file is
-                                                    given, then only the variation analysis is run.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/MSA">Multiple Sequence Alignment and SNP/Variation
-                                                            Analysis</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/msa_snp_variation_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/msa_snp_variation/msa_snp_variation.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Proteome Comparison</h3>
-                                                <p>
-                                                    The Proteome Comparison Service performs protein sequence-based
-                                                    genome comparison using bidirectional BLASTP. This service allows
-                                                    users to select genomes and compare them to reference genome.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/SeqComparison">Proteome Comparison</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/proteome_comparison_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/proteome_comparison/proteome_comparison.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Gene Tree</h3>
-                                                <p>
-                                                    The Gene Tree Service is being tested.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/GeneTree">Gene Tree</a></li>
-                                                    <li><a href="https://www.maage-brc.org/docs/quick_references/services/genetree.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a href="https://www.maage-brc.org/docs/tutorial/genetree/genetree.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <!-- <h3>Protein Family Sorter <span style="font-style: italic;">(B)</span></h3>
-                                        <p></p>
-                                        <ul>
-                                            <li><a href="/app/ProteinFamily">Protein Family Sorter</a></li>
-                                            <li><a href="https://www.maage-brc.org/docs/quick_references/services/protein_family_service.html">Quick Reference Guide</a></li>
-                                            <li><a href="https://www.maage-brc.org/docs/tutorial/protein_family_sorter/protein_family_sorter.html">Tutorial</a></li>
-                                        </ul>
-                                        <h3>Proteome Comparison <span style="font-style: italic;">(B)</span></h3>
-                                        <p>
-                                            The Proteome Comparison Service performs protein sequence-based genome comparison using bidirectional BLASTP. This service allows users to select genomes and compare them to reference genome.
-                                        </p>
-                                        <ul>
-                                            <li><a href="/app/SeqComparison"></a></li>
-                                            <li><a href="https://www.maage-brc.org/docs/quick_references/services/proteome_comparison_service.html">Quick Reference Guide</a></li>
-                                            <li><a href="https://www.maage-brc.org/docs/tutorial/proteome_comparison/proteome_comparison.html">Tutorial</a></li>
-                                        </ul> -->
-                                                <!-- <h3>Comparative Pathway <span style="font-style: italic;">(B)</span></h3>
-                                        <p>
-                                            The Comparative Pathway Service allows users to identify a set of pathways based on taxonomy, EC number, pathway ID, pathway name and/or specific annotation type.
-                                        </p>
-                                        <ul>
-                                            <li><a href="/app/ComparativePathway">Comparative Pathway Tool</a></li>
-                                            <li><a href="https://www.maage-brc.org/docs/quick_references/services/comparative_pathway_service.html">Quick Reference Guide</a></li>
-                                            <li><a href="">Tutorial</a></li>
-                                        </ul> -->
-                                                <h3>Metagenomic Read Mapping</h3>
-                                                <p>
-                                                    The Metagenomic Read Mapping Service uses KMA to align reads against
-                                                    antibiotic resistance genes from CARD and virulence factors from
-                                                    VFDB.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/MetagenomicReadMapping">Metagenomic Read
-                                                            Mapping</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/metagenomic_read_mapping_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/metagenomic_read_mapping/metagenomic_read_mapping.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Taxonomic Classification</h3>
-                                                <p>
-                                                    The Taxonomic Classification Service computes taxonomic
-                                                    classification for read data.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/TaxonomicClassification">Taxonomic
-                                                            Classification</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/taxonomic_classification_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/taxonomic_classification/taxonomic_classification.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Metagenomic Binning</h3>
-                                                <p>
-                                                    The Metagenomic Binning Service accepts either reads or contigs, and
-                                                    attempts to "bin" the data into a set of genomes. This service can
-                                                    be used to reconstruct bacterial and archael genomes from
-                                                    environmental samples.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/MetagenomicBinning">Metagenomic Binning</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/metagenomic_binning_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/metagenomic_binning/metagenomic_binning.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Expression Import</h3>
-                                                <p>
-                                                    The Differential Expression Import Service facilitates upload of
-                                                    user-provided, pre-processed differential expression datasets
-                                                    generated by microarray, RNA-Seq, or proteomic technologies to the
-                                                    user's private workspace.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/Expression">Differential Expression Import</a>
-                                                    </li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/expression_data_import_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/expression_import/expression_import.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>RNA-Seq Analysis</h3>
-                                                <p>
-                                                    The RNA-Seq Analysis Service provides services for aligning,
-                                                    assembling, and testing differential expression on RNA-Seq data.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/Rnaseq">RNA-Seq Analysis</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/rna_seq_analysis_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a href="https://www.maage-brc.org/docs/tutorial/rna_seq/rna_seq.html">Tutorial</a></li>
-                                                </ul>
-                                                <h3>ID Mapper</h3>
-                                                <p>
-                                                    The ID Mapper tool maps PATRIC identifiers to those from other
-                                                    prominent external databases such as GenBank, RefSeq, EMBL, UniProt,
-                                                    KEGG, etc. Alternatively, it can map a list of external database
-                                                    identifiers to the corresponding PATRIC features.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/IDMapper">ID Mapper</a></li>
-                                                    <li><a href="https://www.maage-brc.org/docs/quick_references/services/id_mapper.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a href="https://www.maage-brc.org/docs/tutorial/id_mapper/id_mapper.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                                <h3>Fastq Utilities</h3>
-                                                <p>
-                                                    The Fastq Utilites Service provides capability for aligning,
-                                                    measuring base call quality, and trimmiing fastq read files.
-                                                </p>
-                                                <ul>
-                                                    <li><a href="/app/FastqUtil">Fastq Utilities</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/quick_references/services/fastq_utilities_service.html">Quick
-                                                            Reference Guide</a></li>
-                                                    <li><a
-                                                            href="https://www.maage-brc.org/docs/tutorial/fastq_utilities/fastq_utilities.html">Tutorial</a>
-                                                    </li>
-                                                </ul>
-                                            </div>
+                                  <div style="font-family:'Poppins',sans-serif;font-weight:600;font-size:1.4em;padding-bottom:4px;border-bottom:2px solid #548fa6;margin-bottom:12px;margin-top:8px;">Genomics</div>
 
-                                            <div class="tools-flex-right"></div>
-                                        </div>
+                                  <h3><a href="/app/Assembly2">Genome Assembly</a></h3>
+                                  <p>
+                                    Allows single or multiple assemblers to be invoked to compare results. The service
+                                    attempts to select the best assembly.
+                                  </p>
+                                  <br>
 
-                                    </div>
+                                  <h3><a href="/app/Annotation">Genome Annotation</a></h3>
+                                  <p>
+                                    Provides annotation of genomic features using the RAST tool kit (RASTtk) for bacteria
+                                    and VIGOR4 for viruses. Accepts a FASTA formatted contig file and an annotation recipe
+                                    based on taxonomy.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/ComprehensiveGenomeAnalysis">Comprehensive Genome Analysis</a></h3>
+                                  <p>
+                                    A streamlined meta-service that accepts raw reads and performs assembly, annotation,
+                                    identification of nearest neighbors, a subsystem summary, phylogenetic tree, and
+                                    features that distinguish the genome from its nearest neighbors.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/Homology">BLAST</a></h3>
+                                  <p>
+                                    Uses BLAST (Basic Local Alignment Search Tool) to search against public or private
+                                    genomes or other databases using DNA or protein sequences.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/GenomeDistance">Similar Genome Finder</a></h3>
+                                  <p>
+                                    Finds similar public genomes or computes genome distance estimation using Mash/MinHash.
+                                    Returns a set of genomes matching the specified similarity criteria.
+                                  </p>
+                                  <br>
+
+                                  <div style="font-family:'Poppins',sans-serif;font-weight:600;font-size:1.4em;padding-bottom:4px;border-bottom:2px solid #548fa6;margin-bottom:12px;margin-top:8px;">Metagenomics</div>
+
+                                  <h3><a href="/app/TaxonomicClassification">Taxonomic Classification</a></h3>
+                                  <p>
+                                    Computes taxonomic classification for read data using a k-mer-based approach to
+                                    rapidly assign taxonomy to metagenomic reads.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/MetagenomicBinning">Metagenomic Binning</a></h3>
+                                  <p>
+                                    Accepts reads or contigs and attempts to bin the data into a set of genomes. Can be
+                                    used to reconstruct bacterial and archaeal genomes from environmental samples.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/MetagenomicReadMapping">Metagenomic Read Mapping</a></h3>
+                                  <p>
+                                    Uses KMA to align reads against antibiotic resistance genes from CARD and virulence
+                                    factors from VFDB.
+                                  </p>
+                                  <br>
+
+                                  <div style="font-family:'Poppins',sans-serif;font-weight:600;font-size:1.4em;padding-bottom:4px;border-bottom:2px solid #548fa6;margin-bottom:12px;margin-top:8px;">Phylogenomics</div>
+
+                                  <h3><a href="/app/CoreGenomeMLST">Core Genome MLST</a></h3>
+                                  <p>
+                                    Performs core genome multilocus sequence typing (cgMLST) for high-resolution
+                                    genotyping and clustering of microbial genomes.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/WholeGenomeSNPAnalysis">Whole Genome SNP Analysis</a></h3>
+                                  <p>
+                                    Identifies whole-genome single nucleotide polymorphisms (SNPs) across a set of genomes
+                                    for phylogenetic analysis and outbreak investigation.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/PhylogeneticTree">Bacterial Genome Tree</a></h3>
+                                  <p>
+                                    Enables construction of custom phylogenetic trees for user-selected bacterial genomes
+                                    using conserved marker genes.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/ViralGenomeTree">Viral Genome Tree</a></h3>
+                                  <p>
+                                    Enables construction of custom phylogenetic trees for user-selected viral genomes
+                                    using conserved marker genes.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/GeneTree">Gene/Protein Tree</a></h3>
+                                  <p>
+                                    Builds phylogenetic trees from user-selected genes or proteins using multiple sequence
+                                    alignment and standard tree-building methods.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/MSA">MSA and SNP Analysis</a></h3>
+                                  <p>
+                                    Performs multiple sequence alignment with variation and SNP analysis on feature groups,
+                                    FASTA files, aligned FASTA files, or user-provided sequences.
+                                  </p>
+                                  <br>
+
+                                  <div style="font-family:'Poppins',sans-serif;font-weight:600;font-size:1.4em;padding-bottom:4px;border-bottom:2px solid #548fa6;margin-bottom:12px;margin-top:8px;">Viral Tools</div>
+
+                                  <h3><a href="/app/ComprehensiveSARS2Analysis">SARS-CoV-2 Genome Analysis</a></h3>
+                                  <p>
+                                    A streamlined meta-service that accepts raw reads and performs genome assembly,
+                                    annotation, and variation analysis for SARS-CoV-2.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/SARS2Wastewater">SARS-CoV-2 Wastewater Analysis</a></h3>
+                                  <p>
+                                    Analyzes wastewater sequencing data to detect and quantify SARS-CoV-2 variants for
+                                    community-level surveillance.
+                                  </p>
+                                  <br>
+
+                                  <h3><a href="/app/ViralAssembly">Viral Assembly</a></h3>
+                                  <p>
+                                    Assembles viral genomes from sequencing reads using methods optimized for the
+                                    characteristics of viral genomes.
+                                  </p>
 
                                 </div>
                             </div>


### PR DESCRIPTION
- Renamed 'Advanced Searches' page title/heading to 'Searches'
- Trimmed searches page to match navbar items (removed Proteins, Protein Structures, Pathways, Subsystems)
- Rewrote tools page to match navbar categories (Genomics, Metagenomics, Phylogenomics, Viral Tools)
- Linked h3 titles directly to each tool/search; removed redundant bullet lists
- Added brief descriptions for all tools
- Increased category header size and border weight on tools page