### PR TITLE
Fix broken workflow image path on BacterialInvestigation page

### DIFF
--- a/public/js/p3/widget/app/templates/BacterialInvestigationOverview.html
+++ b/public/js/p3/widget/app/templates/BacterialInvestigationOverview.html
@@ -17,7 +17,7 @@
 
   <!-- Workflow Diagram -->
   <div class="mb-6">
-    <img src="/maage/img/bacterialinvestigationworkflow.png" alt="Bacterial Investigation Workflow diagram" style="width:100%; height:auto; display:block;"/>
+    <img src="/maage/img/BacterialInvestigationWorkflow.png" alt="Bacterial Investigation Workflow diagram" style="width:100%; height:auto; display:block;"/>
   </div>
 
   <!-- Step 1 -->


### PR DESCRIPTION
## Summary

The workflow diagram image on `/app/BacterialInvestigation` was broken (404). The template referenced `/maage/img/bacterialinvestigationworkflow.png` (lowercase), but the file on disk is `BacterialInvestigationWorkflow.png` (PascalCase).

The mismatch is invisible on case-insensitive filesystems (macOS) but 404s on the case-sensitive Linux server (`dev.maage-brc.org`). Fixed the reference to match the actual filename — consistent with the sibling `ViralInvestigationOverview.html`, which already used the correct casing.

## Testing

Confirmed the on-disk filename (`public/maage/img/BacterialInvestigationWorkflow.png`) now matches the template `src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)